### PR TITLE
chore: add SwiftLint pre-commit hook and CI workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+echo "iOS Pre-commit: running SwiftLint..."
+
+# Coletar arquivos Swift staged
+STAGED_SWIFT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$' || true)
+
+if [ -z "$STAGED_SWIFT" ]; then
+    echo "No Swift files staged — skipping SwiftLint"
+    exit 0
+fi
+
+if ! command -v swiftlint > /dev/null 2>&1; then
+    echo "WARNING: SwiftLint not installed locally — CI will enforce on PR"
+    echo "Install: brew install swiftlint"
+    exit 0
+fi
+
+SWIFTLINT_VERSION=$(swiftlint version 2>/dev/null || echo "unknown")
+echo "SwiftLint $SWIFTLINT_VERSION"
+
+# Rodar swiftlint nos arquivos staged
+echo "$STAGED_SWIFT" | xargs swiftlint lint --quiet --strict
+LINT_EXIT=$?
+
+if [ $LINT_EXIT -ne 0 ]; then
+    echo "SwiftLint FAILED — fix errors above before committing"
+    echo "Tip: swiftlint lint --fix to auto-fix some issues"
+    exit 1
+fi
+
+echo "SwiftLint OK"
+exit 0

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,31 @@
+name: SwiftLint
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '**/*.swift'
+      - '.swiftlint.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.swift'
+      - '.swiftlint.yml'
+
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: |
+          swiftlint lint \
+            --strict \
+            --reporter github-actions-logging

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,59 @@
+disabled_rules:
+  - trailing_whitespace
+  - line_length
+  - todo
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - empty_string
+  - first_where
+  - implicit_return
+  - last_where
+  - literal_expression_end_indentation
+  - multiline_arguments
+  - multiline_parameters
+  - operator_usage_whitespace
+  - prefer_self_type_over_type_of_self
+  - redundant_nil_coalescing
+  - sorted_first_last
+  - toggle_bool
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+
+included:
+  - VitaAI
+
+excluded:
+  - Pods
+  - .build
+  - DerivedData
+  - .swiftpm
+
+reporter: "xcode"
+
+# Customizações
+identifier_name:
+  min_length:
+    error: 2
+  excluded:
+    - id
+    - to
+    - vm
+    - db
+    - ok
+
+type_body_length:
+  warning: 300
+  error: 400
+
+file_length:
+  warning: 500
+  error: 700
+
+function_body_length:
+  warning: 60
+  error: 100


### PR DESCRIPTION
## Summary

- `.swiftlint.yml` configurado para o projeto VitaAI (inclui `VitaAI/`)
- `.githooks/pre-commit`: roda SwiftLint nos arquivos Swift staged antes de cada commit; faz graceful skip se `swiftlint` nao estiver instalado localmente (CI enforça)
- `.github/workflows/swiftlint.yml`: CI no `macos-14` com `--strict --reporter github-actions-logging` em todos os PRs com arquivos `.swift`

## Regras habilitadas

- `opt_in_rules`: `empty_count`, `closure_spacing`, `first_where`, `last_where`, `toggle_bool`, e outras boas praticas Swift
- `disabled_rules`: `trailing_whitespace`, `line_length`, `todo` (nao queremos bloquear WIP)
- Limites: `type_body_length` 300/400, `file_length` 500/700, `function_body_length` 60/100

## Como usar localmente

```bash
# Instalar
brew install swiftlint

# Ativar hook (ja feito via git config)
git config core.hooksPath .githooks

# Auto-fix
swiftlint lint --fix
```

## Test plan

- [ ] CI workflow roda em macos-14 e retorna anotacoes inline no PR
- [ ] Hook executa ao commitar arquivos .swift
- [ ] Hook passa silenciosamente quando swiftlint nao esta instalado

Generated with Claude Code