### PR TITLE
feat(ios): Transcrição de Áudio — record, upload, SSE stream, transcript + summary + flashcards

### DIFF
--- a/VitaAI/Features/Estudos/EstudosScreen.swift
+++ b/VitaAI/Features/Estudos/EstudosScreen.swift
@@ -13,6 +13,8 @@ struct EstudosScreen: View {
     var onNavigateToFlashcardStats:    (() -> Void)?
     var onNavigateToPdfViewer:         ((URL) -> Void)?
     var onNavigateToSimulados:         (() -> Void)?
+    var onNavigateToQBank:             (() -> Void)?
+    var onNavigateToTranscricao:       (() -> Void)?
 
     @State private var viewModel: EstudosViewModel?
 
@@ -27,7 +29,9 @@ struct EstudosScreen: View {
                     onNavigateToFlashcardSession: onNavigateToFlashcardSession,
                     onNavigateToFlashcardStats:   onNavigateToFlashcardStats,
                     onNavigateToPdfViewer:        onNavigateToPdfViewer,
-                    onNavigateToSimulados:        onNavigateToSimulados
+                    onNavigateToSimulados:        onNavigateToSimulados,
+                    onNavigateToQBank:            onNavigateToQBank,
+                    onNavigateToTranscricao:      onNavigateToTranscricao
                 )
             } else {
                 ProgressView()
@@ -54,6 +58,8 @@ private struct EstudosContent: View {
     let onNavigateToFlashcardStats:    (() -> Void)?
     let onNavigateToPdfViewer:         ((URL) -> Void)?
     let onNavigateToSimulados:         (() -> Void)?
+    let onNavigateToQBank:             (() -> Void)?
+    let onNavigateToTranscricao:       (() -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -93,6 +99,8 @@ private extension EstudosContent {
                 viewModel: viewModel,
                 onCourseClick: { courseId in viewModel.selectCourse(courseId) },
                 onNavigateToSimulados: onNavigateToSimulados,
+                onNavigateToQBank: onNavigateToQBank,
+                onNavigateToTranscricao: onNavigateToTranscricao,
                 onRefresh: { await viewModel.load() }
             )
 
@@ -321,6 +329,8 @@ private struct DisciplinasTab: View {
     @Bindable var viewModel: EstudosViewModel
     let onCourseClick: (String) -> Void
     var onNavigateToSimulados: (() -> Void)?
+    var onNavigateToQBank: (() -> Void)?
+    var onNavigateToTranscricao: (() -> Void)?
     var onRefresh: (() async -> Void)?
 
     @State private var isGridView = false
@@ -354,6 +364,20 @@ private struct DisciplinasTab: View {
                     // Simulados entry card
                     if let onSimulados = onNavigateToSimulados {
                         SimuladosEntryCard(onTap: onSimulados)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 4)
+                    }
+
+                    // QBank entry card
+                    if let onQBank = onNavigateToQBank {
+                        QBankEntryCard(onTap: onQBank)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 4)
+                    }
+
+                    // Transcrição entry card
+                    if let onTranscricao = onNavigateToTranscricao {
+                        TranscricaoEntryCard(onTap: onTranscricao)
                             .padding(.horizontal, 16)
                             .padding(.bottom, 8)
                     }
@@ -439,6 +463,82 @@ private struct SimuladosEntryCard: View {
                             .fontWeight(.semibold)
                             .foregroundStyle(VitaColors.textPrimary)
                         Text("Pratique com questões de múltipla escolha")
+                            .font(VitaTypography.labelSmall)
+                            .foregroundStyle(VitaColors.textSecondary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12))
+                        .foregroundStyle(VitaColors.textTertiary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - QBank Entry Card
+
+private struct QBankEntryCard: View {
+    let onTap: () -> Void
+    var body: some View {
+        Button(action: onTap) {
+            VitaGlassCard {
+                HStack(spacing: 14) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(VitaColors.dataGreen.opacity(0.12))
+                            .frame(width: 44, height: 44)
+                        Image(systemName: "list.bullet.clipboard")
+                            .font(.system(size: 20))
+                            .foregroundStyle(VitaColors.dataGreen)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Banco de Questões")
+                            .font(VitaTypography.bodyLarge)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(VitaColors.textPrimary)
+                        Text("Pratique com questões reais de residência médica")
+                            .font(VitaTypography.labelSmall)
+                            .foregroundStyle(VitaColors.textSecondary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12))
+                        .foregroundStyle(VitaColors.textTertiary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Transcrição Entry Card
+
+private struct TranscricaoEntryCard: View {
+    let onTap: () -> Void
+    var body: some View {
+        Button(action: onTap) {
+            VitaGlassCard {
+                HStack(spacing: 14) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(VitaColors.dataIndigo.opacity(0.12))
+                            .frame(width: 44, height: 44)
+                        Image(systemName: "waveform")
+                            .font(.system(size: 20))
+                            .foregroundStyle(VitaColors.dataIndigo)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Transcrição de Áudio")
+                            .font(VitaTypography.bodyLarge)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(VitaColors.textPrimary)
+                        Text("Transcreva aulas e gere resumo + flashcards com IA")
                             .font(VitaTypography.labelSmall)
                             .foregroundStyle(VitaColors.textSecondary)
                     }

--- a/VitaAI/Features/Transcricao/TranscricaoScreen.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoScreen.swift
@@ -1,0 +1,861 @@
+import SwiftUI
+import UIKit
+
+// MARK: - TranscricaoScreen
+
+struct TranscricaoScreen: View {
+    let onBack: () -> Void
+
+    @Environment(\.appContainer) private var container
+    @State private var viewModel: TranscricaoViewModel?
+
+    var body: some View {
+        Group {
+            if let vm = viewModel {
+                TranscricaoContent(viewModel: vm, onBack: onBack)
+            } else {
+                ZStack {
+                    VitaColors.surface.ignoresSafeArea()
+                    ProgressView().tint(VitaColors.accent)
+                }
+            }
+        }
+        .task {
+            if viewModel == nil {
+                let vm = TranscricaoViewModel(tokenStore: container.tokenStore)
+                viewModel = vm
+                await vm.checkAndRequestMicPermission()
+            }
+        }
+    }
+}
+
+// MARK: - TranscricaoContent
+
+private struct TranscricaoContent: View {
+    @Bindable var viewModel: TranscricaoViewModel
+    let onBack: () -> Void
+
+    var body: some View {
+        ZStack {
+            VitaColors.surface.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // Header
+                TranscricaoHeader(onBack: onBack)
+
+                // Phase-driven content
+                Group {
+                    switch viewModel.phase {
+                    case .idle:
+                        TranscricaoIdleView(viewModel: viewModel)
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
+
+                    case .recording:
+                        TranscricaoRecordingView(viewModel: viewModel)
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
+
+                    case .uploading, .transcribing, .summarizing, .generatingFlashcards:
+                        TranscricaoProcessingView(viewModel: viewModel)
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
+
+                    case .done:
+                        TranscricaoDoneView(viewModel: viewModel)
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+
+                    case .error(let message):
+                        TranscricaoErrorView(message: message, onRetry: viewModel.reset)
+                            .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                    }
+                }
+                .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.phase)
+            }
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+// MARK: - Header
+
+private struct TranscricaoHeader: View {
+    let onBack: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(VitaColors.textPrimary)
+                    .frame(width: 40, height: 40)
+                    .background(VitaColors.glassBg)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(VitaColors.glassBorder, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Transcrição de Áudio")
+                    .font(VitaTypography.titleLarge)
+                    .foregroundStyle(VitaColors.textPrimary)
+                Text("Grave ou importe e obtenha transcrição + resumo + flashcards")
+                    .font(VitaTypography.bodySmall)
+                    .foregroundStyle(VitaColors.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+    }
+}
+
+// MARK: - Idle Phase
+
+private struct TranscricaoIdleView: View {
+    let viewModel: TranscricaoViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Hero record button
+            VStack(spacing: 24) {
+                // Mic button
+                Button {
+                    viewModel.startRecording()
+                } label: {
+                    ZStack {
+                        // Outer ambient ring
+                        Circle()
+                            .fill(VitaColors.accent.opacity(0.08))
+                            .frame(width: 130, height: 130)
+
+                        // Mid ring
+                        Circle()
+                            .fill(VitaColors.accent.opacity(0.14))
+                            .frame(width: 108, height: 108)
+
+                        // Core
+                        Circle()
+                            .fill(VitaColors.accent)
+                            .frame(width: 88, height: 88)
+
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 36, weight: .medium))
+                            .foregroundStyle(VitaColors.black)
+                    }
+                }
+                .buttonStyle(.plain)
+                .sensoryFeedback(.impact(weight: .medium), trigger: viewModel.phase == .recording)
+                .disabled(!viewModel.micPermissionGranted)
+                .opacity(viewModel.micPermissionGranted ? 1 : 0.4)
+
+                VStack(spacing: 6) {
+                    Text(viewModel.micPermissionGranted ? "Toque para gravar" : "Permissao de microfone necessaria")
+                        .font(VitaTypography.titleMedium)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+                        .multilineTextAlignment(.center)
+
+                    Text("Transcrição + resumo + flashcards gerados automaticamente")
+                        .font(VitaTypography.bodySmall)
+                        .foregroundStyle(VitaColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+
+            // Mic permission hint
+            if !viewModel.micPermissionGranted {
+                VitaGlassCard {
+                    HStack(spacing: 10) {
+                        Image(systemName: "mic.slash")
+                            .font(.system(size: 16))
+                            .foregroundStyle(VitaColors.dataAmber)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Acesso ao microfone necessario")
+                                .font(VitaTypography.labelMedium)
+                                .foregroundStyle(VitaColors.textPrimary)
+                            Text("Vá em Ajustes > VitaAI > Microfone para ativar")
+                                .font(VitaTypography.bodySmall)
+                                .foregroundStyle(VitaColors.textSecondary)
+                        }
+
+                        Spacer()
+
+                        Button("Ajustes") {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                        .font(VitaTypography.labelMedium)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.accent)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 32)
+            } else {
+                // How it works chips
+                HStack(spacing: 8) {
+                    ForEach(["Gravar", "Transcrever", "Resumir", "Flashcards"], id: \.self) { step in
+                        Text(step)
+                            .font(VitaTypography.labelSmall)
+                            .foregroundStyle(VitaColors.textSecondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(VitaColors.glassBg)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(VitaColors.glassBorder, lineWidth: 1))
+                    }
+                }
+                .padding(.bottom, 32)
+            }
+        }
+    }
+}
+
+// MARK: - Recording Phase
+
+private struct TranscricaoRecordingView: View {
+    let viewModel: TranscricaoViewModel
+
+    @State private var pulseScale: CGFloat = 1.0
+    @State private var wavePhase: Double = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 32) {
+                // Animated waveform bars
+                WaveformBarsView(amplitude: viewModel.micAmplitude)
+                    .frame(height: 60)
+                    .padding(.horizontal, 48)
+
+                // Pulsing stop button
+                ZStack {
+                    // Pulse rings
+                    Circle()
+                        .fill(VitaColors.dataRed.opacity(0.08))
+                        .frame(width: 130, height: 130)
+                        .scaleEffect(pulseScale)
+
+                    Circle()
+                        .fill(VitaColors.dataRed.opacity(0.12))
+                        .frame(width: 108, height: 108)
+
+                    // Stop button core
+                    Button {
+                        viewModel.stopRecording()
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(VitaColors.dataRed)
+                                .frame(width: 88, height: 88)
+
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(VitaColors.white)
+                                .frame(width: 30, height: 30)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                        pulseScale = 1.18
+                    }
+                }
+
+                // Elapsed time + label
+                VStack(spacing: 6) {
+                    Text(formatElapsed(viewModel.elapsedSeconds))
+                        .font(.system(size: 36, weight: .bold, design: .monospaced))
+                        .foregroundStyle(VitaColors.textPrimary)
+
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(VitaColors.dataRed)
+                            .frame(width: 8, height: 8)
+                        Text("Gravando... toque para parar")
+                            .font(VitaTypography.bodySmall)
+                            .foregroundStyle(VitaColors.textSecondary)
+                    }
+                }
+            }
+
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Waveform Bars
+
+private struct WaveformBarsView: View {
+    let amplitude: Float
+
+    private let barCount = 28
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            HStack(spacing: 3) {
+                ForEach(0..<barCount, id: \.self) { i in
+                    let phase = Double(i) * 0.4
+                    let wave = sin(t * 5.0 + phase) * 0.5 + 0.5
+                    let baseHeight: Double = 8
+                    let maxExtra: Double = 44
+                    let height = baseHeight + maxExtra * wave * Double(amplitude)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(
+                            LinearGradient(
+                                colors: [VitaColors.accent, VitaColors.accentDark],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .frame(width: 3, height: max(baseHeight, height))
+                        .animation(.linear(duration: 0.05), value: amplitude)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Processing Phase
+
+private struct TranscricaoProcessingView: View {
+    let viewModel: TranscricaoViewModel
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 32) {
+                // Rotating accent ring
+                ZStack {
+                    Circle()
+                        .stroke(VitaColors.accent.opacity(0.12), lineWidth: 4)
+                        .frame(width: 88, height: 88)
+
+                    Circle()
+                        .trim(from: 0, to: 0.72)
+                        .stroke(
+                            AngularGradient(
+                                colors: [VitaColors.accent, VitaColors.accent.opacity(0.1)],
+                                center: .center
+                            ),
+                            style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                        )
+                        .frame(width: 88, height: 88)
+                        .rotationEffect(.degrees(rotation))
+                        .onAppear {
+                            withAnimation(.linear(duration: 1.1).repeatForever(autoreverses: false)) {
+                                rotation = 360
+                            }
+                        }
+
+                    Image(systemName: phaseIcon)
+                        .font(.system(size: 28, weight: .medium))
+                        .foregroundStyle(VitaColors.accent)
+                }
+
+                VStack(spacing: 12) {
+                    Text(viewModel.phase.processingLabel)
+                        .font(VitaTypography.titleMedium)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+                        .multilineTextAlignment(.center)
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.phase.processingLabel)
+
+                    if viewModel.progressPercent > 0 {
+                        VStack(spacing: 6) {
+                            // Progress bar
+                            GeometryReader { geo in
+                                ZStack(alignment: .leading) {
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(VitaColors.accent.opacity(0.12))
+                                        .frame(height: 6)
+
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(
+                                            LinearGradient(
+                                                colors: [VitaColors.accent, VitaColors.accentLight],
+                                                startPoint: .leading,
+                                                endPoint: .trailing
+                                            )
+                                        )
+                                        .frame(width: geo.size.width * CGFloat(viewModel.progressPercent) / 100, height: 6)
+                                        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: viewModel.progressPercent)
+                                }
+                            }
+                            .frame(height: 6)
+                            .padding(.horizontal, 48)
+
+                            Text("\(viewModel.progressPercent)%")
+                                .font(VitaTypography.labelSmall)
+                                .foregroundStyle(VitaColors.textTertiary)
+                                .monospacedDigit()
+                        }
+                    }
+
+                    // Stage pills
+                    HStack(spacing: 8) {
+                        StagePill(label: "Upload", isDone: isDoneStage(.uploading), isActive: isActiveStage(.uploading))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 8))
+                            .foregroundStyle(VitaColors.textTertiary)
+                        StagePill(label: "Transcrição", isDone: isDoneStage(.transcribing), isActive: isActiveStage(.transcribing))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 8))
+                            .foregroundStyle(VitaColors.textTertiary)
+                        StagePill(label: "Resumo", isDone: isDoneStage(.summarizing), isActive: isActiveStage(.summarizing))
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 8))
+                            .foregroundStyle(VitaColors.textTertiary)
+                        StagePill(label: "Cards", isDone: isDoneStage(.generatingFlashcards), isActive: isActiveStage(.generatingFlashcards))
+                    }
+                }
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+        }
+    }
+
+    private var phaseIcon: String {
+        switch viewModel.phase {
+        case .uploading:            return "arrow.up.circle"
+        case .transcribing:         return "text.bubble"
+        case .summarizing:          return "doc.text.magnifyingglass"
+        case .generatingFlashcards: return "rectangle.stack"
+        default:                    return "gearshape.2"
+        }
+    }
+
+    private func isActiveStage(_ target: TranscricaoPhase) -> Bool {
+        viewModel.phase == target
+    }
+
+    private func isDoneStage(_ target: TranscricaoPhase) -> Bool {
+        let order: [TranscricaoPhase] = [.uploading, .transcribing, .summarizing, .generatingFlashcards]
+        guard let current = order.firstIndex(of: viewModel.phase),
+              let targetIdx = order.firstIndex(of: target) else { return false }
+        return current > targetIdx
+    }
+}
+
+private struct StagePill: View {
+    let label: String
+    let isDone: Bool
+    let isActive: Bool
+
+    var body: some View {
+        Text(label)
+            .font(VitaTypography.labelSmall)
+            .foregroundStyle(
+                isDone ? VitaColors.dataGreen :
+                isActive ? VitaColors.accent :
+                VitaColors.textTertiary
+            )
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(
+                        isDone ? VitaColors.dataGreen.opacity(0.12) :
+                        isActive ? VitaColors.accent.opacity(0.12) :
+                        VitaColors.glassBg
+                    )
+            )
+    }
+}
+
+// MARK: - Done Phase
+
+private struct TranscricaoDoneView: View {
+    @Bindable var viewModel: TranscricaoViewModel
+
+    @State private var selectedTab: Int = 0
+    @State private var copiedToast: Bool = false
+
+    private let tabs = ["Transcrição", "Resumo", "Flashcards"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Tab selector
+            HStack(spacing: 0) {
+                ForEach(Array(tabs.enumerated()), id: \.offset) { idx, title in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) { selectedTab = idx }
+                    } label: {
+                        VStack(spacing: 6) {
+                            Text(title)
+                                .font(VitaTypography.labelMedium)
+                                .fontWeight(selectedTab == idx ? .semibold : .regular)
+                                .foregroundStyle(
+                                    selectedTab == idx ? VitaColors.accent : VitaColors.textSecondary
+                                )
+                            Rectangle()
+                                .fill(selectedTab == idx ? VitaColors.accent : Color.clear)
+                                .frame(height: 2)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .animation(.easeInOut(duration: 0.2), value: selectedTab)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(VitaColors.glassBorder)
+                    .frame(height: 1)
+            }
+
+            // Tab content
+            Group {
+                switch selectedTab {
+                case 0:
+                    TranscriptTabView(
+                        transcript: viewModel.result?.transcript ?? "",
+                        onCopy: { copyToClipboard(viewModel.result?.transcript ?? "") },
+                        onShare: { shareText(viewModel.result?.transcript ?? "") },
+                        onReset: viewModel.reset
+                    )
+                case 1:
+                    SummaryTabView(
+                        summary: viewModel.result?.summary ?? "",
+                        onCopy: { copyToClipboard(viewModel.result?.summary ?? "") },
+                        onShare: { shareText(viewModel.result?.summary ?? "") },
+                        onReset: viewModel.reset
+                    )
+                case 2:
+                    FlashcardsTabView(
+                        flashcards: viewModel.result?.flashcards ?? [],
+                        onReset: viewModel.reset
+                    )
+                default:
+                    EmptyView()
+                }
+            }
+            .transition(.opacity)
+            .animation(.easeInOut(duration: 0.2), value: selectedTab)
+        }
+        .overlay(alignment: .top) {
+            if copiedToast {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(VitaColors.dataGreen)
+                    Text("Copiado!")
+                        .font(VitaTypography.labelMedium)
+                        .foregroundStyle(VitaColors.textPrimary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+                .padding(.top, 8)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+    }
+
+    private func copyToClipboard(_ text: String) {
+        UIPasteboard.general.string = text
+        withAnimation(.spring(response: 0.3)) { copiedToast = true }
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeOut(duration: 0.3)) { copiedToast = false }
+        }
+    }
+
+    private func shareText(_ text: String) {
+        guard !text.isEmpty else { return }
+        let activityVC = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootVC = windowScene.windows.first?.rootViewController {
+            var presented = rootVC
+            while let next = presented.presentedViewController { presented = next }
+            presented.present(activityVC, animated: true)
+        }
+    }
+}
+
+// MARK: - Transcript Tab
+
+private struct TranscriptTabView: View {
+    let transcript: String
+    let onCopy: () -> Void
+    let onShare: () -> Void
+    let onReset: () -> Void
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 16) {
+                // Action row
+                HStack {
+                    Text("Transcrição completa")
+                        .font(VitaTypography.titleSmall)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+
+                    Spacer()
+
+                    HStack(spacing: 8) {
+                        ActionIconButton(systemImage: "doc.on.doc", tint: VitaColors.accent, action: onCopy)
+                        ActionIconButton(systemImage: "square.and.arrow.up", tint: VitaColors.accent, action: onShare)
+                    }
+                }
+
+                // Content card
+                VitaGlassCard {
+                    Text(transcript.isEmpty ? "Nenhuma transcrição disponível." : transcript)
+                        .font(VitaTypography.bodySmall)
+                        .foregroundStyle(transcript.isEmpty ? VitaColors.textTertiary : VitaColors.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(14)
+                }
+
+                // Nova transcrição
+                VitaButton(
+                    text: "Nova Transcrição",
+                    action: onReset,
+                    variant: .secondary,
+                    size: .md,
+                    leadingSystemImage: "arrow.counterclockwise"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .padding(16)
+            .padding(.bottom, 32)
+        }
+    }
+}
+
+// MARK: - Summary Tab
+
+private struct SummaryTabView: View {
+    let summary: String
+    let onCopy: () -> Void
+    let onShare: () -> Void
+    let onReset: () -> Void
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    Text("Resumo da aula")
+                        .font(VitaTypography.titleSmall)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+
+                    Spacer()
+
+                    HStack(spacing: 8) {
+                        ActionIconButton(systemImage: "doc.on.doc", tint: VitaColors.accent, action: onCopy)
+                        ActionIconButton(systemImage: "square.and.arrow.up", tint: VitaColors.accent, action: onShare)
+                    }
+                }
+
+                VitaGlassCard {
+                    Text(summary.isEmpty ? "Nenhum resumo disponível." : summary)
+                        .font(VitaTypography.bodySmall)
+                        .foregroundStyle(summary.isEmpty ? VitaColors.textTertiary : VitaColors.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(14)
+                }
+
+                VitaButton(
+                    text: "Nova Transcrição",
+                    action: onReset,
+                    variant: .secondary,
+                    size: .md,
+                    leadingSystemImage: "arrow.counterclockwise"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .padding(16)
+            .padding(.bottom, 32)
+        }
+    }
+}
+
+// MARK: - Flashcards Tab
+
+private struct FlashcardsTabView: View {
+    let flashcards: [TranscriptionFlashcard]
+    let onReset: () -> Void
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 12) {
+                HStack {
+                    Text("\(flashcards.count) flashcard\(flashcards.count == 1 ? "" : "s") gerado\(flashcards.count == 1 ? "" : "s")")
+                        .font(VitaTypography.titleSmall)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+
+                    Spacer()
+
+                    ActionIconButton(
+                        systemImage: "arrow.counterclockwise",
+                        tint: VitaColors.accent,
+                        action: onReset
+                    )
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+
+                if flashcards.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "rectangle.stack")
+                            .font(.system(size: 32))
+                            .foregroundStyle(VitaColors.textTertiary)
+                        Text("Nenhum flashcard gerado")
+                            .font(VitaTypography.bodyMedium)
+                            .foregroundStyle(VitaColors.textSecondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 48)
+                } else {
+                    ForEach(flashcards) { card in
+                        FlashcardItemView(card: card)
+                            .padding(.horizontal, 16)
+                    }
+                }
+
+                VitaButton(
+                    text: "Nova Transcrição",
+                    action: onReset,
+                    variant: .secondary,
+                    size: .md,
+                    leadingSystemImage: "arrow.counterclockwise"
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 32)
+            }
+        }
+    }
+}
+
+private struct FlashcardItemView: View {
+    let card: TranscriptionFlashcard
+
+    var body: some View {
+        VitaGlassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                // Front
+                Text(card.front)
+                    .font(VitaTypography.bodyMedium)
+                    .fontWeight(.medium)
+                    .foregroundStyle(VitaColors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                // Divider
+                Rectangle()
+                    .fill(VitaColors.glassBorder)
+                    .frame(height: 1)
+
+                // Back
+                Text(card.back)
+                    .font(VitaTypography.bodySmall)
+                    .foregroundStyle(VitaColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(14)
+        }
+    }
+}
+
+// MARK: - Error Phase
+
+private struct TranscricaoErrorView: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                // Icon
+                ZStack {
+                    Circle()
+                        .fill(VitaColors.dataRed.opacity(0.12))
+                        .frame(width: 80, height: 80)
+
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 32, weight: .medium))
+                        .foregroundStyle(VitaColors.dataRed)
+                }
+
+                VStack(spacing: 8) {
+                    Text("Algo deu errado")
+                        .font(VitaTypography.titleMedium)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VitaColors.textPrimary)
+
+                    Text(message)
+                        .font(VitaTypography.bodySmall)
+                        .foregroundStyle(VitaColors.dataRed)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                }
+
+                VitaButton(
+                    text: "Tentar novamente",
+                    action: onRetry,
+                    variant: .primary,
+                    size: .lg,
+                    leadingSystemImage: "arrow.counterclockwise"
+                )
+            }
+            .padding(.horizontal, 32)
+
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Action Icon Button
+
+private struct ActionIconButton: View {
+    let systemImage: String
+    let tint: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(tint)
+                .frame(width: 36, height: 36)
+                .background(tint.opacity(0.10))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Helpers
+
+private func formatElapsed(_ seconds: Int) -> String {
+    let m = seconds / 60
+    let s = seconds % 60
+    return String(format: "%02d:%02d", m, s)
+}

--- a/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
@@ -1,0 +1,367 @@
+import Foundation
+import AVFoundation
+
+// MARK: - TranscricaoPhase
+// Mirrors Android TranscricaoViewModel.Phase
+
+enum TranscricaoPhase: Equatable {
+    case idle
+    case recording
+    case uploading
+    case transcribing
+    case summarizing
+    case generatingFlashcards
+    case done
+    case error(String)
+}
+
+// MARK: - TranscriptionFlashcard
+
+struct TranscriptionFlashcard: Identifiable {
+    let id: UUID
+    let front: String
+    let back: String
+
+    init(front: String, back: String) {
+        self.id = UUID()
+        self.front = front
+        self.back = back
+    }
+}
+
+// MARK: - TranscricaoResult
+
+struct TranscricaoResult {
+    let transcript: String
+    let summary: String
+    let flashcards: [TranscriptionFlashcard]
+}
+
+// MARK: - TranscricaoViewModel
+
+@MainActor
+@Observable
+final class TranscricaoViewModel: NSObject {
+
+    // MARK: - State
+
+    private(set) var phase: TranscricaoPhase = .idle
+    private(set) var elapsedSeconds: Int = 0
+    private(set) var progressPercent: Int = 0
+    private(set) var progressStage: String = ""
+    private(set) var result: TranscricaoResult? = nil
+    private(set) var micPermissionGranted: Bool = false
+
+    // MARK: - Dependencies
+
+    private let tokenStore: TokenStore
+
+    // MARK: - Audio Recording
+
+    private var audioRecorder: AVAudioRecorder?
+    private var recordingURL: URL?
+    private var elapsedTimer: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(tokenStore: TokenStore) {
+        self.tokenStore = tokenStore
+    }
+
+    // MARK: - Permission
+
+    func checkAndRequestMicPermission() async {
+        let current = AVCaptureDevice.authorizationStatus(for: .audio)
+        if current == .authorized {
+            micPermissionGranted = true
+            return
+        }
+        let granted = await AVAudioApplication.requestRecordPermission()
+        micPermissionGranted = granted
+    }
+
+    // MARK: - Record
+
+    func startRecording() {
+        guard micPermissionGranted else { return }
+
+        // Temp file in app cache dir
+        let fileName = "vita_transcricao_\(Int(Date().timeIntervalSince1970)).m4a"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        recordingURL = url
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+        ]
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .default)
+            try session.setActive(true)
+
+            audioRecorder = try AVAudioRecorder(url: url, settings: settings)
+            audioRecorder?.delegate = self
+            audioRecorder?.isMeteringEnabled = true
+            audioRecorder?.record()
+
+            phase = .recording
+            elapsedSeconds = 0
+            startElapsedTimer()
+        } catch {
+            phase = .error("Falha ao iniciar gravação: \(error.localizedDescription)")
+        }
+    }
+
+    func stopRecording() {
+        audioRecorder?.stop()
+        elapsedTimer?.cancel()
+        elapsedTimer = nil
+
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            // Non-critical
+        }
+
+        guard let url = recordingURL else {
+            phase = .error("Falha ao parar gravação")
+            return
+        }
+
+        phase = .uploading
+        progressPercent = 0
+        progressStage = ""
+
+        Task { @MainActor in
+            await self.uploadAndStream(url: url)
+        }
+    }
+
+    // MARK: - Upload + SSE Stream
+
+    private func uploadAndStream(url: URL) async {
+        guard let token = await tokenStore.token else {
+            phase = .error("Sessao expirada. Faca login novamente.")
+            return
+        }
+
+        guard let apiURL = URL(string: AppConfig.apiBaseURL + "/ai/transcribe") else {
+            phase = .error("URL de API invalida.")
+            return
+        }
+
+        // Build multipart form data
+        let boundary = "VitaBoundary-\(UUID().uuidString)"
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        // Generous timeouts for audio upload + transcription
+        request.timeoutInterval = 300
+
+        do {
+            let audioData = try Data(contentsOf: url)
+            let body = buildMultipartBody(audioData: audioData, fileName: url.lastPathComponent, boundary: boundary)
+            request.httpBody = body
+        } catch {
+            phase = .error("Falha ao ler arquivo de audio: \(error.localizedDescription)")
+            return
+        }
+
+        // Stream SSE response
+        do {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = 300
+            config.timeoutIntervalForResource = 600
+            let session = URLSession(configuration: config)
+
+            let (bytes, response) = try await session.bytes(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                phase = .error("Erro do servidor (\(code)). Tente novamente.")
+                return
+            }
+
+            var dataBuffer = ""
+
+            for try await line in bytes.lines {
+                if line.hasPrefix("data:") {
+                    dataBuffer += line.dropFirst(5).trimmingCharacters(in: .whitespaces)
+                } else if line.isEmpty && !dataBuffer.isEmpty {
+                    let raw = dataBuffer
+                    dataBuffer = ""
+                    processSSEData(raw)
+                }
+            }
+
+            // Ensure we are done if stream ends without explicit complete event
+            if case .transcribing = phase {
+                phase = .error("Conexao encerrada antes da conclusao. Tente novamente.")
+            } else if case .uploading = phase {
+                phase = .error("Conexao encerrada antes da conclusao. Tente novamente.")
+            }
+
+        } catch {
+            phase = .error("Erro de conexao: \(error.localizedDescription)")
+        }
+
+        // Clean up temp file
+        try? FileManager.default.removeItem(at: url)
+        recordingURL = nil
+    }
+
+    private func processSSEData(_ raw: String) {
+        guard let data = raw.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else { return }
+
+        switch type {
+        case "progress":
+            let stage = json["stage"] as? String ?? ""
+            let percent = json["percent"] as? Int ?? 0
+            progressPercent = percent
+            progressStage = stage
+            phase = stageToPhase(stage)
+
+        case "complete":
+            let transcript = json["transcript"] as? String ?? ""
+            let summary = json["summary"] as? String ?? ""
+            var flashcards: [TranscriptionFlashcard] = []
+            if let cards = json["flashcards"] as? [[String: Any]] {
+                flashcards = cards.compactMap { card in
+                    guard let front = card["front"] as? String,
+                          let back = card["back"] as? String else { return nil }
+                    return TranscriptionFlashcard(front: front, back: back)
+                }
+            }
+            result = TranscricaoResult(transcript: transcript, summary: summary, flashcards: flashcards)
+            progressPercent = 100
+            phase = .done
+
+        case "error":
+            let msg = json["content"] as? String ?? "Erro desconhecido"
+            phase = .error(msg)
+
+        default:
+            break
+        }
+    }
+
+    private func stageToPhase(_ stage: String) -> TranscricaoPhase {
+        let lower = stage.lowercased()
+        if lower.contains("transcri") { return .transcribing }
+        if lower.contains("resum") { return .summarizing }
+        if lower.contains("flash") { return .generatingFlashcards }
+        return .uploading
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        audioRecorder?.stop()
+        audioRecorder = nil
+        elapsedTimer?.cancel()
+        elapsedTimer = nil
+        if let url = recordingURL {
+            try? FileManager.default.removeItem(at: url)
+            recordingURL = nil
+        }
+        phase = .idle
+        elapsedSeconds = 0
+        progressPercent = 0
+        progressStage = ""
+        result = nil
+    }
+
+    // MARK: - Elapsed Timer
+
+    private func startElapsedTimer() {
+        elapsedTimer?.cancel()
+        elapsedTimer = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard let self, !Task.isCancelled else { break }
+                self.elapsedSeconds += 1
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func buildMultipartBody(audioData: Data, fileName: String, boundary: String) -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+
+        // Audio field
+        body.append("--\(boundary)\(crlf)".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"audio\"; filename=\"\(fileName)\"\(crlf)".data(using: .utf8)!)
+        body.append("Content-Type: audio/m4a\(crlf)\(crlf)".data(using: .utf8)!)
+        body.append(audioData)
+        body.append(crlf.data(using: .utf8)!)
+
+        // Closing boundary
+        body.append("--\(boundary)--\(crlf)".data(using: .utf8)!)
+
+        return body
+    }
+
+    // MARK: - Waveform amplitude (for visualization)
+
+    var micAmplitude: Float {
+        audioRecorder?.updateMeters()
+        let power = audioRecorder?.averagePower(forChannel: 0) ?? -60
+        // Normalize from [-60, 0] dB to [0, 1]
+        let normalized = (power + 60) / 60
+        return max(0, min(1, normalized))
+    }
+}
+
+// MARK: - AVAudioRecorderDelegate
+
+extension TranscricaoViewModel: AVAudioRecorderDelegate {
+    nonisolated func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        Task { @MainActor in
+            if !flag {
+                // Only surface error if we were still expecting to record
+                if case .recording = self.phase {
+                    self.phase = .error("Gravacao encerrada inesperadamente")
+                }
+            }
+        }
+    }
+
+    nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        Task { @MainActor in
+            self.phase = .error("Erro de codificacao: \(error?.localizedDescription ?? "desconhecido")")
+        }
+    }
+}
+
+// MARK: - Phase helpers
+
+extension TranscricaoPhase {
+    var processingLabel: String {
+        switch self {
+        case .uploading:            return "Enviando audio..."
+        case .transcribing:         return "Transcrevendo audio..."
+        case .summarizing:          return "Gerando resumo..."
+        case .generatingFlashcards: return "Criando flashcards..."
+        default:                    return "Processando..."
+        }
+    }
+
+    var isProcessing: Bool {
+        switch self {
+        case .uploading, .transcribing, .summarizing, .generatingFlashcards:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/VitaAI/Navigation/AppRouter.swift
+++ b/VitaAI/Navigation/AppRouter.swift
@@ -75,7 +75,9 @@ struct MainTabView: View {
                                 onNavigateToFlashcardSession:   { deckId in router.navigate(to: .flashcardSession(deckId: deckId)) },
                                 onNavigateToFlashcardStats:     { router.navigate(to: .flashcardStats) },
                                 onNavigateToPdfViewer:          { url in router.navigate(to: .pdfViewer(url: url.absoluteString)) },
-                                onNavigateToSimulados:          { router.navigate(to: .simuladoHome) }
+                                onNavigateToSimulados:          { router.navigate(to: .simuladoHome) },
+                                onNavigateToQBank:              { router.navigate(to: .qbankHome) },
+                                onNavigateToTranscricao:        { router.navigate(to: .transcricao) }
                             )
                             .tag(TabItem.estudos)
 
@@ -198,6 +200,18 @@ struct MainTabView: View {
                     )
                 case .simuladoDiagnostics:
                     SimuladoDiagnosticsScreen(
+                        onBack: { router.goBack() }
+                    )
+                case .qbankHome:
+                    QBankCoordinatorScreen(
+                        onBack: { router.goBack() }
+                    )
+                case .osce:
+                    OsceScreen(
+                        onBack: { router.goBack() }
+                    )
+                case .transcricao:
+                    TranscricaoScreen(
                         onBack: { router.goBack() }
                     )
                 case .canvasConnect:

--- a/VitaAI/Navigation/Route.swift
+++ b/VitaAI/Navigation/Route.swift
@@ -28,6 +28,15 @@ enum Route: Hashable {
     case simuladoReview(attemptId: String)
     case simuladoDiagnostics
 
+    // MARK: - QBank
+    case qbankHome
+
+    // MARK: - OSCE
+    case osce
+
+    // MARK: - Transcricao
+    case transcricao
+
     // MARK: - Settings sub-screens
     case about
     case appearance


### PR DESCRIPTION
## Summary

- Full iOS port of Android `TranscricaoScreen.kt` / `TranscricaoViewModel.kt`
- `TranscricaoViewModel` — `@Observable @MainActor`, AVAudioRecorder for m4a capture, multipart upload to `POST /api/ai/transcribe`, SSE streaming parses `progress` / `complete` / `error` events
- `TranscricaoScreen` — phase-driven SwiftUI: Idle → Recording (animated waveform + pulse stop button) → Processing (spinner + stage pills + progress bar) → Done (3-tab: Transcrição / Resumo / Flashcards with copy/share/reset) → Error
- `Route.transcricao` added; wired in `AppRouter` and from `EstudosScreen` DisciplinasTab as a `TranscricaoEntryCard`
- All design tokens from `VitaColors` / `VitaTypography` — zero hardcoded colors
- Microphone permission handled with `AVAudioApplication.requestRecordPermission()` + Settings deep-link if denied

## Test plan

- [ ] Tap "Transcrição de Áudio" entry card in Estudos > Disciplinas tab
- [ ] Idle screen shows mic button; deny mic permission → banner with "Ajustes" link appears
- [ ] Grant permission → tap record button → recording phase shows waveform + elapsed time
- [ ] Tap stop → uploads and transitions through Processing stages (Enviando → Transcrevendo → Gerando resumo → Criando flashcards)
- [ ] Done view: three tabs each show correct content; copy copies to clipboard; share opens share sheet
- [ ] "Nova Transcrição" resets to idle
- [ ] Error state shows retry button that returns to idle
- [ ] Back button returns to EstudosScreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)