### PR TITLE
feat(dashboard): SHIELD design feedback — contrast bumps + hero card

### DIFF
--- a/VitaAI/Data/Mock/MockData.swift
+++ b/VitaAI/Data/Mock/MockData.swift
@@ -68,6 +68,19 @@ enum MockData {
         ]
     }
 
+    static func continueStudying() -> ContinueStudyingItem {
+        ContinueStudyingItem(
+            subject: "Anatomia Humana II",
+            sessionType: "Flashcards",
+            progress: 0.42,
+            cardsDone: 19,
+            cardsTotal: 45,
+            streakDays: 12,
+            daysUntilExam: 3,
+            studyInsight: "Voce acerta 92% quando revisa antes de dormir"
+        )
+    }
+
     static func studyTip() -> String {
         let tips = [
             "Técnica Pomodoro: 25min de foco, 5min de pausa. Após 4 ciclos, 15min de pausa longa.",

--- a/VitaAI/DesignSystem/Theme/VitaColors.swift
+++ b/VitaAI/DesignSystem/Theme/VitaColors.swift
@@ -45,4 +45,9 @@ enum VitaColors {
     static let dataAmber  = VitaTokens.PrimitiveColors.amber500     // #f59e0b
     static let dataBlue   = VitaTokens.PrimitiveColors.blue400      // #60a5fa
     static let dataIndigo = VitaTokens.PrimitiveColors.indigo400    // #a78bfa (card back accent)
+
+    // Hero card badge colors — ContinueStudyingCard (SHIELD design feedback)
+    static let badgeStreak  = Color(red: 0.510, green: 0.784, blue: 0.549)   // (130,200,140)/255 — green streak
+    static let badgeUrgency = Color(red: 1.000, green: 0.471, blue: 0.314)   // (255,120,80)/255  — red-orange urgency
+    static let ctaGold      = Color(red: 0.784, green: 0.627, blue: 0.314)   // (200,160,80)/255  — CTA button gradient start
 }

--- a/VitaAI/DesignSystem/Tokens.swift
+++ b/VitaAI/DesignSystem/Tokens.swift
@@ -18,7 +18,7 @@ enum VitaTokens {
         static let borderSurface = Color(red: 0.102, green: 0.125, blue: 0.157)
         static let text = Color(red: 1.000, green: 1.000, blue: 1.000).opacity(0.85)
         static let textSecondary = Color(red: 1.000, green: 1.000, blue: 1.000).opacity(0.55)
-        static let textMuted = Color(red: 1.000, green: 1.000, blue: 1.000).opacity(0.25)
+        static let textMuted = Color(red: 1.000, green: 1.000, blue: 1.000).opacity(0.35)     // was 0.25 — contrast bump (SHIELD feedback)
         static let dataBlue = Color(red: 0.376, green: 0.647, blue: 0.980)
         static let dataGreen = Color(red: 0.290, green: 0.871, blue: 0.502)
         static let dataAmber = Color(red: 0.984, green: 0.749, blue: 0.141)

--- a/VitaAI/Features/Dashboard/Components/ContinueStudyingCard.swift
+++ b/VitaAI/Features/Dashboard/Components/ContinueStudyingCard.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+// MARK: - ContinueStudyingCard
+// Hero card displayed on Dashboard when the student has an active study session to resume.
+// Design reference: vita-app.html hero card section.
+// Model: ContinueStudyingItem is defined in DashboardModels.swift.
+
+struct ContinueStudyingCard: View {
+    let item: ContinueStudyingItem
+    var onContinue: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Top: subject + type row
+            headerRow
+
+            // Progress bar
+            progressRow
+                .padding(.top, 14)
+
+            // Insight
+            insightRow
+                .padding(.top, 12)
+
+            // Badges row
+            badgesRow
+                .padding(.top, 10)
+
+            // CTA button
+            ctaButton
+                .padding(.top, 16)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            // Slightly richer background than standard glass card to signal hero status
+            LinearGradient(
+                colors: [
+                    VitaColors.accentSubtle.opacity(0.65),
+                    VitaColors.glassBg
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(VitaColors.accent.opacity(0.20), lineWidth: 1)
+        )
+        .shadow(color: VitaColors.accent.opacity(0.12), radius: 16, y: 6)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: Sub-views
+
+    private var headerRow: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Play icon circle
+            ZStack {
+                Circle()
+                    .fill(VitaColors.accent.opacity(0.15))
+                    .frame(width: 44, height: 44)
+
+                Image(systemName: "play.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(VitaColors.accent)
+                    .offset(x: 1)
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(NSLocalizedString("continue_studying_title", comment: "Continue Studying"))
+                    .font(VitaTypography.labelSmall)
+                    .foregroundStyle(VitaColors.accent)
+                    .kerning(0.8)
+                    .textCase(.uppercase)
+
+                Text("\(item.subject) · \(item.sessionType)")
+                    .font(VitaTypography.titleMedium)
+                    .foregroundStyle(VitaColors.textPrimary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var progressRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Bar
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.white.opacity(0.08))
+                        .frame(height: 6)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(
+                            LinearGradient(
+                                colors: [VitaColors.accentLight, VitaColors.accent],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: geo.size.width * item.progress, height: 6)
+                }
+            }
+            .frame(height: 6)
+
+            // Counter
+            HStack {
+                Text(String(format: NSLocalizedString("progress_cards_format", comment: "%d de %d cards"), item.cardsDone, item.cardsTotal))
+                    .font(VitaTypography.bodySmall)
+                    .foregroundStyle(VitaColors.textTertiary)
+
+                Spacer()
+
+                Text("\(Int(item.progress * 100))%")
+                    .font(VitaTypography.labelSmall)
+                    .foregroundStyle(VitaColors.textSecondary)
+            }
+        }
+    }
+
+    private var insightRow: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 12))
+                .foregroundStyle(VitaColors.accentLight)
+
+            Text(item.studyInsight)
+                .font(VitaTypography.bodySmall)
+                .foregroundStyle(VitaColors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var badgesRow: some View {
+        HStack(spacing: 8) {
+            // Streak badge — always shown
+            badge(
+                icon: "flame.fill",
+                label: String(format: NSLocalizedString("streak_days_format", comment: "%d dias"), item.streakDays),
+                foreground: VitaColors.badgeStreak,
+                background: VitaColors.badgeStreak.opacity(0.15)
+            )
+
+            // Urgency badge — only when exam is soon
+            if let days = item.daysUntilExam {
+                badge(
+                    icon: "exclamationmark.circle.fill",
+                    label: String(format: NSLocalizedString("exam_days_format", comment: "Prova em %d dias"), days),
+                    foreground: VitaColors.badgeUrgency,
+                    background: VitaColors.badgeUrgency.opacity(0.15)
+                )
+            }
+
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private func badge(icon: String, label: String, foreground: Color, background: Color) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundStyle(foreground)
+
+            Text(label)
+                .font(VitaTypography.labelSmall)
+                .foregroundStyle(foreground)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(background)
+        .clipShape(Capsule())
+    }
+
+    private var ctaButton: some View {
+        Button(action: onContinue) {
+            HStack(spacing: 8) {
+                Text(NSLocalizedString("continue_studying_cta", comment: "CONTINUAR ESTUDANDO"))
+                    .font(VitaTypography.labelLarge)
+                    .kerning(0.5)
+
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundStyle(VitaColors.black)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 13)
+            .background(
+                LinearGradient(
+                    colors: [VitaColors.ctaGold, VitaColors.accentDark],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(color: VitaColors.accent.opacity(0.30), radius: 8, y: 3)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/VitaAI/Features/Dashboard/Components/WeekAgendaSection.swift
+++ b/VitaAI/Features/Dashboard/Components/WeekAgendaSection.swift
@@ -5,7 +5,7 @@ struct WeekAgendaSection: View {
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
+            HStack(spacing: 10) {
                 ForEach(days) { day in
                     VStack(spacing: 6) {
                         Text(day.label)
@@ -31,11 +31,11 @@ struct WeekAgendaSection: View {
                         .frame(height: 24)
                     }
                     .frame(width: 70)
-                    .padding(.vertical, 10)
+                    .padding(.vertical, 12)
                     .glassCard(cornerRadius: 12)
                 }
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 16)
         }
     }
 }

--- a/VitaAI/Features/Dashboard/DashboardScreen.swift
+++ b/VitaAI/Features/Dashboard/DashboardScreen.swift
@@ -60,9 +60,16 @@ struct DashboardScreen: View {
                     .padding(.horizontal, 20)
                 }
 
+                // Hero Card — Continue Studying
+                if let item = viewModel.continueStudying {
+                    ContinueStudyingCard(item: item, onContinue: {
+                        onNavigateToFlashcards?()
+                    })
+                }
+
                 // Upcoming Exams
                 if !viewModel.upcomingExams.isEmpty {
-                    SectionHeader(title: "Próximas Provas")
+                    SectionHeader(title: "Proximas Provas")
                     UpcomingExamsRow(exams: viewModel.upcomingExams)
                 }
 

--- a/VitaAI/Features/Dashboard/DashboardViewModel.swift
+++ b/VitaAI/Features/Dashboard/DashboardViewModel.swift
@@ -12,6 +12,7 @@ final class DashboardViewModel {
     var studyModules: [StudyModule] = []
     var studyTip: String = ""
     var suggestions: [VitaSuggestion] = []
+    var continueStudying: ContinueStudyingItem?
     var isLoading = true
     var error: String?
 
@@ -65,5 +66,6 @@ final class DashboardViewModel {
         studyModules = MockData.studyModules()
         studyTip = MockData.studyTip()
         suggestions = MockData.vitaSuggestions()
+        continueStudying = MockData.continueStudying()
     }
 }

--- a/VitaAI/Models/Domain/DashboardModels.swift
+++ b/VitaAI/Models/Domain/DashboardModels.swift
@@ -38,3 +38,16 @@ struct VitaSuggestion: Identifiable {
     let label: String
     let prompt: String
 }
+
+// MARK: - Hero Card Model
+
+struct ContinueStudyingItem {
+    let subject: String        // ex: "Anatomia Humana II"
+    let sessionType: String    // ex: "Flashcards"
+    let progress: Double       // 0.0 – 1.0
+    let cardsDone: Int
+    let cardsTotal: Int
+    let streakDays: Int
+    let daysUntilExam: Int?    // nil = sem prova proxima
+    let studyInsight: String   // insight personalizado
+}

--- a/VitaAI/Resources/pt-BR.lproj/Localizable.strings
+++ b/VitaAI/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,12 @@
+/* VitaAI — pt-BR (default language) */
+
+/* ContinueStudyingCard */
+"continue_studying_title" = "Continuar Estudando";
+"continue_studying_cta"   = "CONTINUAR ESTUDANDO";
+"progress_cards_format"   = "%d de %d cards";
+"streak_days_format"      = "%d dias";
+"exam_days_format"        = "Prova em %d dias";
+"study_insight_night_review" = "Voce acerta 92%% quando revisa antes de dormir";
+
+/* DashboardScreen section headers */
+"section_upcoming_exams"  = "Proximas Provas";


### PR DESCRIPTION
## Summary

- **Contraste:** `textMuted` alpha bumped de 0.25 → 0.35 em `Tokens.swift`, impacta todos os textos terciarios: tab bar icones/labels inativos, labels de dia da agenda, texto de eventos
- **Agenda spacing:** gap entre itens 8→10pt, padding vertical 10→12pt, margem lateral 20→16pt
- **Hero card:** novo `ContinueStudyingCard` com play icon, barra de progresso, insight de estudo, badge pills (streak verde + urgencia laranja), botao CTA dourado
- **Tokens de badge:** `badgeStreak`, `badgeUrgency`, `ctaGold` adicionados em `VitaColors.swift`
- **i18n:** arquivo `Resources/pt-BR.lproj/Localizable.strings` criado com todas as chaves novas do hero card

## Arquivos modificados

- `VitaAI/DesignSystem/Tokens.swift` — textMuted contrast bump
- `VitaAI/DesignSystem/Theme/VitaColors.swift` — badge/CTA tokens
- `VitaAI/Features/Dashboard/Components/WeekAgendaSection.swift` — spacing
- `VitaAI/Features/Dashboard/Components/ContinueStudyingCard.swift` — novo hero card
- `VitaAI/Features/Dashboard/DashboardScreen.swift` — integra hero card
- `VitaAI/Features/Dashboard/DashboardViewModel.swift` — continueStudying property
- `VitaAI/Models/Domain/DashboardModels.swift` — ContinueStudyingItem model
- `VitaAI/Data/Mock/MockData.swift` — mock data
- `VitaAI/Resources/pt-BR.lproj/Localizable.strings` — localizacao

## Test plan

- [ ] Abrir Dashboard — hero card "Continuar Estudando" aparece entre o XP bar e Proximas Provas
- [ ] Verificar badge streak (verde) e urgencia (laranja) vissiveis no hero card
- [ ] Botao CTA dourado com gradiente e texto escuro
- [ ] Tap no CTA navega para Flashcards
- [ ] Tab bar icones inativos com contraste melhorado (35% alpha vs 25% antes)
- [ ] Itens da agenda com spacing maior (gap 10pt, padding vertical 12pt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)