### PR TITLE
fix(auth): correct signup and forgot-password endpoints

### DIFF
--- a/VitaAI/Core/Auth/AuthManager.swift
+++ b/VitaAI/Core/Auth/AuthManager.swift
@@ -83,26 +83,23 @@ final class AuthManager: ObservableObject {
         error = nil
         defer { isLoading = false }
 
-        guard let url = URL(string: "\(AppConfig.authBaseURL)/api/auth/sign-up/email") else {
+        guard let url = URL(string: "\(AppConfig.authBaseURL)/api/auth/mobile-email-register") else {
             error = "URL inválida"; return
         }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONSerialization.data(withJSONObject: ["email": email, "password": password, "name": name, "callbackURL": "/"])
+        req.httpBody = try? JSONSerialization.data(withJSONObject: ["email": email, "password": password, "name": name])
 
         await performEmailAuthRequest(req, email: email)
     }
 
     func forgotPassword(email: String) async {
-        guard let url = URL(string: "\(AppConfig.authBaseURL)/api/auth/forget-password") else { return }
+        guard let url = URL(string: "\(AppConfig.authBaseURL)/api/auth/mobile-forgot-password") else { return }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONSerialization.data(withJSONObject: [
-            "email": email,
-            "redirectTo": "\(AppConfig.authBaseURL)/reset-password"
-        ])
+        req.httpBody = try? JSONSerialization.data(withJSONObject: ["email": email])
         _ = try? await URLSession.shared.data(for: req)
     }
 


### PR DESCRIPTION
## Summary

- `signUpWithEmail`: `/api/auth/sign-up/email` → `/api/auth/mobile-email-register`
- `forgotPassword`: `/api/auth/forget-password` → `/api/auth/mobile-forgot-password`
- Removed `callbackURL` field from signup request body (Android doesn't send it)
- Removed `redirectTo` field from forgot-password request body (mobile endpoint only needs `{email}`)

## Root cause

iOS was calling the web/better-auth default endpoints instead of the mobile-specific endpoints that the backend exposes. Android (`AuthManager.kt`) already used the correct paths.

## Test plan

- [ ] Sign up with new email — verify account creation succeeds (no 404)
- [ ] Forgot password with valid email — verify reset email is dispatched (no 404)
- [ ] Sign in with email — unaffected, was already correct (`/api/auth/mobile-email-login`)
- [ ] Google/Apple OAuth — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)