### PR TITLE
feat: ToolManagerScreen with i18n (iOS parity)

### DIFF
--- a/VitaAI/Features/Dashboard/ToolManagerScreen.swift
+++ b/VitaAI/Features/Dashboard/ToolManagerScreen.swift
@@ -1,0 +1,317 @@
+import SwiftUI
+
+// MARK: - Tool Entry Model
+
+struct ToolEntry: Identifiable, Hashable {
+    let id: String
+    let label: LocalizedStringKey
+    let iconName: String // SF Symbol name
+    let route: Route
+}
+
+// MARK: - All Available Tools
+
+private let allTools: [ToolEntry] = [
+    ToolEntry(
+        id: "qbank",
+        label: LocalizedStringKey("tool_manager_questoes"),
+        iconName: "questionmark.circle",
+        route: .qbank
+    ),
+    ToolEntry(
+        id: "flashcards",
+        label: LocalizedStringKey("tool_manager_flashcards"),
+        iconName: "rectangle.on.rectangle.angled",
+        route: .flashcardStats
+    ),
+    ToolEntry(
+        id: "simulados",
+        label: LocalizedStringKey("tool_manager_simulados"),
+        iconName: "doc.text",
+        route: .simuladoHome
+    ),
+    ToolEntry(
+        id: "atlas",
+        label: LocalizedStringKey("tool_manager_atlas"),
+        iconName: "atom",
+        route: .atlas3D
+    ),
+    ToolEntry(
+        id: "resumos",
+        label: LocalizedStringKey("tool_manager_resumos"),
+        iconName: "doc.plaintext",
+        route: .notebookList
+    ),
+    ToolEntry(
+        id: "mapas",
+        label: LocalizedStringKey("tool_manager_mapas"),
+        iconName: "brain.head.profile",
+        route: .mindMapList
+    ),
+    ToolEntry(
+        id: "osce",
+        label: LocalizedStringKey("tool_manager_osce"),
+        iconName: "stethoscope",
+        route: .osce
+    ),
+    ToolEntry(
+        id: "trabalhos",
+        label: LocalizedStringKey("tool_manager_trabalhos"),
+        iconName: "tray.full",
+        route: .trabalhos
+    ),
+    ToolEntry(
+        id: "transcricao",
+        label: LocalizedStringKey("tool_manager_transcricao"),
+        iconName: "mic",
+        route: .transcricao
+    ),
+    ToolEntry(
+        id: "agenda",
+        label: LocalizedStringKey("tool_manager_agenda"),
+        iconName: "calendar",
+        route: .agenda
+    ),
+    ToolEntry(
+        id: "provas",
+        label: LocalizedStringKey("tool_manager_provas"),
+        iconName: "graduationcap",
+        route: .provas
+    ),
+    ToolEntry(
+        id: "cadernos",
+        label: LocalizedStringKey("tool_manager_cadernos"),
+        iconName: "book",
+        route: .notebookList
+    ),
+]
+
+// MARK: - Default Tool IDs
+
+let defaultToolIds: Set<String> = [
+    "qbank", "flashcards", "simulados", "atlas", "resumos", "mapas", "osce",
+]
+
+// MARK: - UserDefaults Key
+
+private let toolManagerSelectedKey = "vita_tool_manager_selected_ids"
+
+// MARK: - Persistence Helpers
+
+func loadSelectedToolIds() -> Set<String> {
+    guard let stored = UserDefaults.standard.array(forKey: toolManagerSelectedKey) as? [String] else {
+        return defaultToolIds
+    }
+    return Set(stored)
+}
+
+func saveSelectedToolIds(_ ids: Set<String>) {
+    UserDefaults.standard.set(Array(ids), forKey: toolManagerSelectedKey)
+}
+
+// MARK: - ToolManagerScreen
+
+struct ToolManagerScreen: View {
+    let onBack: () -> Void
+    let onSave: (Set<String>) -> Void
+
+    @State private var selectedIds: Set<String>
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10),
+    ]
+
+    init(onBack: @escaping () -> Void, onSave: @escaping (Set<String>) -> Void) {
+        self.onBack = onBack
+        self.onSave = onSave
+        _selectedIds = State(initialValue: loadSelectedToolIds())
+    }
+
+    var body: some View {
+        ZStack {
+            VitaColors.surface.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // MARK: - Top Bar
+                topBar
+
+                // MARK: - Selected Counter Pill
+                counterPill
+                    .padding(.horizontal, 20)
+                    .padding(.top, 4)
+
+                Spacer().frame(height: 16)
+
+                // MARK: - Grid
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 12) {
+                        ForEach(allTools) { tool in
+                            ToolGridItem(
+                                tool: tool,
+                                isSelected: selectedIds.contains(tool.id),
+                                onToggle: {
+                                    withAnimation(.easeInOut(duration: 0.2)) {
+                                        if selectedIds.contains(tool.id) {
+                                            selectedIds.remove(tool.id)
+                                        } else {
+                                            selectedIds.insert(tool.id)
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+
+                // MARK: - Save Button
+                saveButton
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 24)
+            }
+        }
+        .navigationBarHidden(true)
+    }
+
+    // MARK: - Top Bar
+
+    private var topBar: some View {
+        HStack(spacing: 0) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(VitaColors.textPrimary)
+                    .frame(width: 48, height: 48)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(LocalizedStringKey("tool_manager_title"))
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(VitaColors.textPrimary)
+
+                Text(LocalizedStringKey("tool_manager_subtitle"))
+                    .font(.system(size: 13))
+                    .foregroundColor(VitaColors.textTertiary)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Counter Pill
+
+    private var counterPill: some View {
+        HStack {
+            Text(String(format: NSLocalizedString("tool_manager_selected_count", comment: ""), selectedIds.count))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(VitaColors.accent)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(VitaColors.accent.opacity(0.12))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(VitaColors.accent.opacity(0.25), lineWidth: 1)
+                        )
+                )
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Save Button
+
+    private var saveButton: some View {
+        Button(action: {
+            saveSelectedToolIds(selectedIds)
+            onSave(selectedIds)
+        }) {
+            Text(LocalizedStringKey("tool_manager_save"))
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(VitaColors.surface)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(VitaColors.accent)
+                )
+        }
+    }
+}
+
+// MARK: - ToolGridItem
+
+private struct ToolGridItem: View {
+    let tool: ToolEntry
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            VStack(spacing: 8) {
+                // Icon container with checkbox overlay
+                ZStack(alignment: .topTrailing) {
+                    // Icon background
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(
+                            isSelected
+                                ? VitaColors.accent.opacity(0.15)
+                                : VitaColors.surfaceElevated.opacity(0.5)
+                        )
+                        .frame(width: 44, height: 44)
+                        .overlay {
+                            Image(systemName: tool.iconName)
+                                .font(.system(size: 20))
+                                .foregroundColor(
+                                    isSelected ? VitaColors.accent : VitaColors.textSecondary
+                                )
+                        }
+
+                    // Checkbox indicator (top-right)
+                    if isSelected {
+                        Circle()
+                            .fill(VitaColors.accent)
+                            .frame(width: 18, height: 18)
+                            .overlay {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 10, weight: .bold))
+                                    .foregroundColor(VitaColors.surface)
+                            }
+                            .offset(x: 4, y: -4)
+                    }
+                }
+                .frame(width: 52, height: 52)
+
+                // Label
+                Text(tool.label)
+                    .font(.system(size: 10, weight: isSelected ? .semibold : .medium))
+                    .foregroundColor(
+                        isSelected ? VitaColors.textPrimary : VitaColors.textSecondary
+                    )
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+            .padding(.vertical, 14)
+            .padding(.horizontal, 6)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(isSelected ? VitaColors.accent.opacity(0.10) : VitaColors.glassBg)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(
+                                isSelected ? VitaColors.accent.opacity(0.5) : VitaColors.glassBorder,
+                                lineWidth: 1
+                            )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/VitaAI/Navigation/AppRouter.swift
+++ b/VitaAI/Navigation/AppRouter.swift
@@ -283,6 +283,11 @@ struct MainTabView: View {
                         onBack: { router.goBack() },
                         onNavigate: { route in router.navigate(to: route) }
                     )
+                case .toolManager:
+                    ToolManagerScreen(
+                        onBack: { router.goBack() },
+                        onSave: { _ in router.goBack() }
+                    )
                 default:
                     EmptyView()
                 }

--- a/VitaAI/Resources/en.lproj/Localizable.strings
+++ b/VitaAI/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+/* Tool Manager */
+"tool_manager_title" = "Tools";
+"tool_manager_subtitle" = "Customize your study tools";
+"tool_manager_selected_count" = "%d selected";
+"tool_manager_save" = "Save";
+"tool_manager_questoes" = "Questions";
+"tool_manager_flashcards" = "Flashcards";
+"tool_manager_simulados" = "Mock Exams";
+"tool_manager_atlas" = "Atlas 3D";
+"tool_manager_resumos" = "Notes";
+"tool_manager_mapas" = "Mind Maps";
+"tool_manager_osce" = "OSCE";
+"tool_manager_trabalhos" = "Assignments";
+"tool_manager_transcricao" = "Transcription";
+"tool_manager_agenda" = "Calendar";
+"tool_manager_provas" = "Exams";
+"tool_manager_cadernos" = "Notebooks";

--- a/VitaAI/Resources/es.lproj/Localizable.strings
+++ b/VitaAI/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+/* Tool Manager */
+"tool_manager_title" = "Herramientas";
+"tool_manager_subtitle" = "Personaliza tus herramientas de estudio";
+"tool_manager_selected_count" = "%d seleccionadas";
+"tool_manager_save" = "Guardar";
+"tool_manager_questoes" = "Preguntas";
+"tool_manager_flashcards" = "Flashcards";
+"tool_manager_simulados" = "Simulacros";
+"tool_manager_atlas" = "Atlas 3D";
+"tool_manager_resumos" = "Resúmenes";
+"tool_manager_mapas" = "Mapas";
+"tool_manager_osce" = "OSCE";
+"tool_manager_trabalhos" = "Trabajos";
+"tool_manager_transcricao" = "Transcripción";
+"tool_manager_agenda" = "Agenda";
+"tool_manager_provas" = "Exámenes";
+"tool_manager_cadernos" = "Cuadernos";

--- a/VitaAI/Resources/pt-BR.lproj/Localizable.strings
+++ b/VitaAI/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,17 @@
+/* Tool Manager */
+"tool_manager_title" = "Ferramentas";
+"tool_manager_subtitle" = "Personalize suas ferramentas de estudo";
+"tool_manager_selected_count" = "%d selecionadas";
+"tool_manager_save" = "Salvar";
+"tool_manager_questoes" = "Questões";
+"tool_manager_flashcards" = "Flashcards";
+"tool_manager_simulados" = "Simulados";
+"tool_manager_atlas" = "Atlas 3D";
+"tool_manager_resumos" = "Resumos";
+"tool_manager_mapas" = "Mapas";
+"tool_manager_osce" = "OSCE";
+"tool_manager_trabalhos" = "Trabalhos";
+"tool_manager_transcricao" = "Transcrição";
+"tool_manager_agenda" = "Agenda";
+"tool_manager_provas" = "Provas";
+"tool_manager_cadernos" = "Cadernos";


### PR DESCRIPTION
## Summary
- Grid-based Tool Manager screen matching Android ToolManagerScreen.kt
- 4-column grid with SF Symbols, animated glassmorphism selection
- UserDefaults persistence for tool toggle state
- First i18n Localizable.strings files (pt-BR, en, es)
- Route added to AppRouter.swift

## References
- Android source: `bymav-mobile/.../ToolManagerScreen.kt`
- BYM-492

## Test plan
- [ ] Verify grid renders with 12 tools
- [ ] Toggle tools on/off, verify animation
- [ ] Kill app + reopen: selections persist
- [ ] Counter pill shows correct count
- [ ] Save button persists and navigates back
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)