### PR TITLE
fix(portal): skip empty transient pages before capturing session

### DIFF
--- a/VitaAI/Features/WebAluno/WebAlunoWebViewScreen.swift
+++ b/VitaAI/Features/WebAluno/WebAlunoWebViewScreen.swift
@@ -357,6 +357,18 @@ struct WebAlunoWebView: UIViewRepresentable {
                     return
                 }
 
+                // Transient post-OAuth stubs (webaluno_login.php&AUTENTICADO=1, redirect=1)
+                // finish with empty DOM (menuLinks=0, frames=0) ~650ms BEFORE Mannesoft
+                // navigates to the real landing page (webaluno_aviso.view.php). If we
+                // capture+inject here, sessionFound=true blocks the next didFinish, and
+                // the bridge we just injected is destroyed by WebKit's navigation —
+                // no vita-bridge-complete, no POST /api/portal/extract, silent failure.
+                // See connector incident 2026-04-17_bridge-empty-html-webview-inject-too-early.md.
+                if hasMenuLinks == 0 && hasFrames == 0 {
+                    NSLog("[WebAluno] Empty transient page (menuLinks=0, frames=0) — waiting for real landing page")
+                    return
+                }
+
                 self.captureSessionIfValid(webView: webView, currentURL: currentURL)
             }
         }


### PR DESCRIPTION
## Summary
Mannesoft OAuth redirect finishes on transient stub pages (webaluno_login.php&AUTENTICADO=1, redirect=1) with empty DOM, 650ms before landing on the real home (webaluno_aviso.view.php). Old gate (loginForm check only) captured session + injected bridge.js on the stub; WebKit destroyed JS state on the next navigation, so bridge never completed and POST /api/portal/extract never fired. Flaky: worked when OAuth/network was slow, failed when fast.

Fix: also require `menuLinks > 0 OR frames > 0` before capturing, so we wait for real content.

## Evidence
Verified live: Rafael reconnected with the fresh build, backend log shows 7 pages captured (home, grades, curriculum, schedule, attendance, calendar, professors — 246KB combined), Haiku processed successfully.

Before (iOS NSLog):
```
23:01:50.450  didFinish webaluno_login.php&AUTENTICADO=1
              Page check: loginForm=0, menuLinks=0, frames=0
              Session captured, bridge.js injected
23:01:51.602  didFinish webaluno_aviso.view.php  (real home, ignored)
              (bridge nuked by navigation)
```

After: first two didFinish are skipped (menuLinks=0, frames=0), capture happens on aviso.view.php with menu frame present.
