### PR TITLE
feat(qbank): PR2b wire + PR2c hero redesign + PR2d session card

### DIFF
--- a/VitaAI/Core/Models/QBankModels.swift
+++ b/VitaAI/Core/Models/QBankModels.swift
@@ -236,6 +236,10 @@ struct QBankCreateSessionRequest: Encodable {
     let difficulties: [String]?
     let topicIds: [Int]?
     let disciplineIds: [Int]?
+    /// MedSimple catalog slugs derived from the selected enrolled/catalog disciplines.
+    /// Backend uses this (via qbank_topics.disciplineSlug) to filter questions; the Int
+    /// `disciplineIds` are local synthetic IDs and are ignored server-side.
+    let disciplineSlugs: [String]?
     let onlyResidence: Bool?
     let onlyUnanswered: Bool?
     let title: String?
@@ -263,6 +267,11 @@ struct QBankProgressResponse: Decodable {
     var accuracy: Double = 0
     var byDifficulty: [QBankProgressByDifficulty] = []
     var byTopic: [QBankProgressByTopic] = []
+    /// "global" when totals reflect the whole catalogue (stage-scoped), "enrolled" when the
+    /// request was filtered by `disciplineSlugs[]`. Added 2026-04-17b.
+    var scope: String? = nil
+    /// Echo of the slugs the server used to scope this response (empty for "global").
+    var scopedSlugs: [String]? = nil
 }
 
 struct QBankProgressByDifficulty: Decodable, Identifiable {
@@ -315,6 +324,9 @@ struct QBankSessionSummary: Decodable, Identifiable {
     var correctCount: Int = 0
     var completedAt: String? = nil
     var createdAt: String = ""
+    /// Display labels for the disciplines this session was scoped to.
+    /// Used as a fallback when `title` is nil; also feeds the chips on the session card.
+    var disciplineTitles: [String]? = nil
 
     var isActive: Bool { completedAt == nil }
 }

--- a/VitaAI/Core/Network/VitaAPI.swift
+++ b/VitaAI/Core/Network/VitaAPI.swift
@@ -291,12 +291,12 @@ actor VitaAPI {
     /// Fetches QBank progress. When `disciplineSlugs` is non-empty, the response is
     /// scoped to the enrolled subset (Hero "X/Y questões das suas matérias") instead of
     /// the global catalog.
-    func getQBankProgress(disciplineSlugs: [String]? = nil) async throws -> QBankProgressResponse {
-        if let slugs = disciplineSlugs, !slugs.isEmpty {
-            let items = slugs.map { URLQueryItem(name: "disciplineSlugs[]", value: $0) }
-            return try await client.get("qbank/progress", queryItems: items)
+    func getQBankProgress(disciplineSlugs: [String] = []) async throws -> QBankProgressResponse {
+        if disciplineSlugs.isEmpty {
+            return try await client.get("qbank/progress")
         }
-        return try await client.get("qbank/progress")
+        let items = disciplineSlugs.map { URLQueryItem(name: "disciplineSlugs[]", value: $0) }
+        return try await client.get("qbank/progress", queryItems: items)
     }
 
     func getQBankFilters() async throws -> QBankFiltersResponse {

--- a/VitaAI/Core/Network/VitaAPI.swift
+++ b/VitaAI/Core/Network/VitaAPI.swift
@@ -288,8 +288,15 @@ actor VitaAPI {
 
     // MARK: - QBank
 
-    func getQBankProgress() async throws -> QBankProgressResponse {
-        try await client.get("qbank/progress")
+    /// Fetches QBank progress. When `disciplineSlugs` is non-empty, the response is
+    /// scoped to the enrolled subset (Hero "X/Y questões das suas matérias") instead of
+    /// the global catalog.
+    func getQBankProgress(disciplineSlugs: [String]? = nil) async throws -> QBankProgressResponse {
+        if let slugs = disciplineSlugs, !slugs.isEmpty {
+            let items = slugs.map { URLQueryItem(name: "disciplineSlugs[]", value: $0) }
+            return try await client.get("qbank/progress", queryItems: items)
+        }
+        return try await client.get("qbank/progress")
     }
 
     func getQBankFilters() async throws -> QBankFiltersResponse {

--- a/VitaAI/Features/QBank/QBankHomeContent.swift
+++ b/VitaAI/Features/QBank/QBankHomeContent.swift
@@ -15,7 +15,10 @@ struct QBankHomeContent: View {
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: 0) {
                         // -- PROGRESS HERO card
-                        QBankProgressHero(progress: vm.state.progress)
+                        QBankProgressHero(
+                            progress: vm.state.progress,
+                            enrolledCount: vm.enrolledDisciplineSlugs.count
+                        )
                             .padding(.horizontal, 16)
                             .padding(.top, 8)
 
@@ -122,7 +125,18 @@ struct QBankHomeContent: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
-        .onAppear { vm.loadHomeData() }
+        .onAppear {
+            vm.loadHomeData()
+        }
+        .onChange(of: vm.state.progressLoading) { _, loading in
+            // After first load completes: if the student has zero enrolled questions
+            // AND zero recent sessions, jump straight to Disciplinas so the Home screen
+            // never shows a lie like "0 / 95.424".
+            guard !loading else { return }
+            if vm.state.progress.totalAvailable == 0 && vm.state.recentSessions.isEmpty {
+                vm.goToDisciplines()
+            }
+        }
     }
 }
 
@@ -177,69 +191,145 @@ struct QBankBackground: View {
     }
 }
 
-// MARK: - Progress Hero (234 / 1.248 big number + bar + accuracy)
+// MARK: - Progress Hero (Faculdade pattern — dark gradient + gold radial + motif + stats strip)
 
 struct QBankProgressHero: View {
     let progress: QBankProgressResponse
+    let enrolledCount: Int
+
+    private var goldPrimary: Color { VitaColors.accentHover }
+    private var goldMuted: Color { VitaColors.accentLight }
 
     var body: some View {
-        VitaGlassCard(cornerRadius: 18) {
-            VStack(alignment: .leading, spacing: 0) {
-                // Big number row
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(formatNumber(progress.totalAnswered))
-                        .font(.system(size: 36, weight: .heavy))
-                        .tracking(-0.04 * 36)
-                        .foregroundStyle(VitaColors.accentLight.opacity(0.92))
+        ZStack(alignment: .topLeading) {
+            heroSolidBackground
+            heroGoldAccent
+            heroQuestionMotif
+            heroContent
+        }
+        .frame(height: 162)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            goldPrimary.opacity(0.40),
+                            goldPrimary.opacity(0.10),
+                            goldPrimary.opacity(0.25)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+        )
+        .shadow(color: .black.opacity(0.30), radius: 14, y: 6)
+    }
 
-                    Text("/ \(formatNumber(progress.totalAvailable))")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(VitaColors.textSecondary)
-                }
+    private var heroSolidBackground: some View {
+        LinearGradient(
+            colors: [
+                Color(red: 0.10, green: 0.07, blue: 0.045),
+                Color(red: 0.05, green: 0.035, blue: 0.022)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
 
-                // Label
-                Text("quest\u{f5}es respondidas")
-                    .font(.system(size: 11))
-                    .foregroundStyle(VitaColors.textSecondary)
-                    .padding(.top, 4)
+    private var heroGoldAccent: some View {
+        RadialGradient(
+            colors: [goldPrimary.opacity(0.22), Color.clear],
+            center: UnitPoint(x: 1.0, y: 0.0),
+            startRadius: 0,
+            endRadius: 140
+        )
+    }
 
-                // Progress bar
-                let pctFill = progress.totalAvailable > 0
-                    ? Double(progress.totalAnswered) / Double(progress.totalAvailable)
-                    : 0
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 99)
-                            .fill(Color.white.opacity(0.06))
-                        RoundedRectangle(cornerRadius: 99)
-                            .fill(
-                                LinearGradient(
-                                    colors: [
-                                        VitaColors.accent.opacity(0.7),
-                                        VitaColors.accentHover.opacity(0.9)
-                                    ],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                            .shadow(color: VitaColors.accentHover.opacity(0.30), radius: 6)
-                            .frame(width: max(geo.size.width * CGFloat(pctFill), 2))
-                    }
-                }
-                .frame(height: 6)
-                .padding(.top, 14)
+    private var heroQuestionMotif: some View {
+        Image(systemName: "questionmark.square.fill")
+            .font(.system(size: 64, weight: .ultraLight))
+            .foregroundStyle(goldPrimary.opacity(0.08))
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            .padding(.top, 14)
+            .padding(.trailing, 16)
+    }
 
-                // Accuracy row
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle")
-                        .font(.system(size: 14, weight: .medium))
-                    Text("\(Int(progress.normalizedAccuracy * 100))% de acerto")
-                        .font(.system(size: 13, weight: .semibold))
-                }
-                .foregroundStyle(VitaColors.dataGreen.opacity(0.85))
-                .padding(.top, 12)
+    private var heroContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Zona 1: eyebrow
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(goldPrimary)
+                    .frame(width: 5, height: 5)
+                Text("SUAS DISCIPLINAS")
+                    .font(.system(size: 10, weight: .bold))
+                    .tracking(1.2)
+                    .foregroundStyle(goldPrimary)
             }
-            .padding(.vertical, 20).padding(.horizontal, 18)
+            .padding(.bottom, 6)
+
+            // Zona 2: big number (enrolled-scoped total)
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(formatNumber(progress.totalAnswered))
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(Color.white)
+                    .kerning(-0.4)
+                    .monospacedDigit()
+                Text("/ \(formatNumber(progress.totalAvailable))")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.55))
+                    .monospacedDigit()
+            }
+
+            HStack(spacing: 6) {
+                Image(systemName: "book.closed.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(goldMuted.opacity(0.75))
+                Text("quest\u{f5}es das suas mat\u{e9}rias")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.72))
+            }
+            .padding(.top, 3)
+
+            Spacer(minLength: 0)
+
+            // Zona 3: stats strip
+            heroStatsStrip
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    private var heroStatsStrip: some View {
+        HStack(spacing: 14) {
+            heroStat(label: "Disciplinas", value: "\(enrolledCount)")
+            heroStatDivider
+            heroStat(label: "Respondidas", value: formatNumber(progress.totalAnswered))
+            heroStatDivider
+            heroStat(label: "Acerto", value: "\(Int(progress.normalizedAccuracy * 100))%")
+            Spacer()
+        }
+    }
+
+    private var heroStatDivider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.12))
+            .frame(width: 1, height: 16)
+    }
+
+    private func heroStat(label: String, value: String) -> some View {
+        HStack(spacing: 5) {
+            Text(value)
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(goldPrimary)
+            Text(label)
+                .font(.system(size: 9, weight: .semibold))
+                .tracking(0.4)
+                .foregroundStyle(Color.white.opacity(0.55))
         }
     }
 
@@ -320,15 +410,25 @@ struct QBankSessionCard: View {
     let action: () -> Void
 
     private var pct: Int {
-        session.totalQuestions > 0
-            ? Int(Double(session.correctCount) / Double(session.totalQuestions) * 100)
-            : 0
+        guard !session.isActive, session.totalQuestions > 0 else { return 0 }
+        return Int(Double(session.correctCount) / Double(session.totalQuestions) * 100)
     }
-    private var metaText: String {
-        if session.isActive {
-            return "\(session.currentIndex)/\(session.totalQuestions) respondidas \u{b7} hoje"
+
+    private var displayTitle: String {
+        if let t = session.title, !t.isEmpty { return t }
+        if let first = session.disciplineTitles?.first, !first.isEmpty {
+            let count = session.disciplineTitles?.count ?? 1
+            return count > 1 ? "\(first) +\(count - 1)" : first
         }
-        return "\(session.correctCount)/\(session.totalQuestions) corretas"
+        return "Sess\u{e3}o de \(session.totalQuestions) quest\u{f5}es"
+    }
+
+    private var metaText: String {
+        let when = Self.formatRelative(session.createdAt)
+        if session.isActive {
+            return "\(session.currentIndex)/\(session.totalQuestions) \u{b7} \(when)"
+        }
+        return "\(session.correctCount)/\(session.totalQuestions) \u{b7} \(pct)% \u{b7} \(when)"
     }
 
     var body: some View {
@@ -357,7 +457,7 @@ struct QBankSessionCard: View {
 
                     // Info
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(session.title ?? "Sess\u{e3}o de \(session.totalQuestions) quest\u{f5}es")
+                        Text(displayTitle)
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundStyle(Color.white.opacity(0.90))
                             .lineLimit(1)
@@ -367,16 +467,66 @@ struct QBankSessionCard: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                    // Accuracy %
-                    Text("\(pct)%")
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundStyle(VitaColors.accentLight.opacity(0.90))
+                    // Accuracy % (only for finished sessions)
+                    if !session.isActive {
+                        Text("\(pct)%")
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(VitaColors.accentLight.opacity(0.90))
+                    } else {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(VitaColors.textSecondary.opacity(0.6))
+                    }
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 14)
             }
         }
         .buttonStyle(.plain)
+    }
+
+    // MARK: - Date formatting (pt_BR)
+
+    private static let iso8601WithFrac: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "pt_BR")
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    private static let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "pt_BR")
+        f.dateFormat = "dd MMM HH:mm"
+        return f
+    }()
+
+    static func formatRelative(_ raw: String, now: Date = Date(), calendar: Calendar = Calendar(identifier: .gregorian)) -> String {
+        guard !raw.isEmpty else { return "" }
+        let date = iso8601WithFrac.date(from: raw) ?? iso8601.date(from: raw)
+        guard let date else { return "" }
+        var cal = calendar
+        cal.locale = Locale(identifier: "pt_BR")
+        cal.timeZone = TimeZone.current
+        let today = cal.startOfDay(for: now)
+        let sessionDay = cal.startOfDay(for: date)
+        if let diff = cal.dateComponents([.day], from: sessionDay, to: today).day {
+            if diff == 0 { return "hoje \(timeFormatter.string(from: date))" }
+            if diff == 1 { return "ontem \(timeFormatter.string(from: date))" }
+        }
+        return shortDateFormatter.string(from: date)
     }
 }
 

--- a/VitaAI/Features/QBank/QBankSessionContent.swift
+++ b/VitaAI/Features/QBank/QBankSessionContent.swift
@@ -226,6 +226,22 @@ struct QBankSessionContent: View {
 
             // Bottom actions
             VStack(spacing: 8) {
+                if let answerError = vm.state.answerError {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(VitaColors.dataRed.opacity(0.9))
+                        Text(answerError)
+                            .font(.system(size: 11))
+                            .foregroundStyle(VitaColors.dataRed.opacity(0.9))
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(VitaColors.dataRed.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
                 if vm.state.showFeedback {
                     HStack(spacing: 10) {
                         Button {

--- a/VitaAI/Features/QBank/QBankViewModel.swift
+++ b/VitaAI/Features/QBank/QBankViewModel.swift
@@ -160,6 +160,23 @@ struct QBankUiState {
     }
 }
 
+extension QBankViewModel {
+    /// Inverse of backend `humanizeSlug`: "Patologia Geral" → "patologia-geral".
+    /// Strips diacritics, lowercases, drops non-alphanumerics, joins words with dashes.
+    static func slugifyDisciplineTitle(_ title: String) -> String {
+        let folded = title.folding(options: .diacriticInsensitive, locale: Locale(identifier: "pt_BR"))
+        let lower = folded.lowercased()
+        let cleaned = lower.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.alphanumerics.contains(scalar) { return Character(scalar) }
+            return " "
+        }
+        let str = String(cleaned)
+        return str
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+    }
+}
+
 // MARK: - ViewModel
 
 @Observable
@@ -222,6 +239,7 @@ final class QBankViewModel {
                     difficulties: nil,
                     topicIds: nil,
                     disciplineIds: nil,
+                    disciplineSlugs: nil,
                     onlyResidence: nil,
                     onlyUnanswered: true,
                     title: nil,
@@ -459,20 +477,31 @@ final class QBankViewModel {
             state.sessionLoading = true
             state.error = nil
             do {
+                // Resolve selected synthetic discipline IDs → catalog slugs.
+                // Backend filters by slug through qbank_topics.disciplineSlug; the Int
+                // `disciplineIds` are iOS-synthetic and intentionally not sent.
+                // Slug is derived from title (strip accents + lowercase + dash-join)
+                // to match backend's humanizeSlug() inverse.
+                let allDisc = QBankUiState.flattenDisciplines(state.filters.disciplines)
+                let selectedSlugs = state.selectedDisciplineIds
+                    .compactMap { id in allDisc.first(where: { $0.id == id })?.title }
+                    .map { Self.slugifyDisciplineTitle($0) }
+                    .filter { !$0.isEmpty }
                 let req = QBankCreateSessionRequest(
                     questionCount: state.questionCount,
                     institutionIds: state.selectedInstitutionIds.isEmpty ? nil : Array(state.selectedInstitutionIds),
                     years: state.selectedYears.isEmpty ? nil : Array(state.selectedYears).sorted(),
                     difficulties: state.selectedDifficulties.isEmpty ? nil : Array(state.selectedDifficulties),
                     topicIds: state.selectedTopicIds.isEmpty ? nil : Array(state.selectedTopicIds),
-                    disciplineIds: state.selectedDisciplineIds.isEmpty ? nil : Array(state.selectedDisciplineIds),
+                    disciplineIds: nil, // synthetic IDs are iOS-only; backend ignores
+                    disciplineSlugs: selectedSlugs.isEmpty ? nil : selectedSlugs,
                     onlyResidence: state.onlyResidence ? true : nil,
                     onlyUnanswered: {
                         if state.selectedStatus == "unanswered" { return true }
                         if state.onlyUnanswered { return true }
                         return nil
                     }(),
-                    title: nil,
+                    title: nil, // backend auto-derives from disciplineSlugs when nil
                     status: state.selectedStatus
                 )
                 let session = try await api.createQBankSession(request: req)

--- a/VitaAI/Features/QBank/QBankViewModel.swift
+++ b/VitaAI/Features/QBank/QBankViewModel.swift
@@ -72,6 +72,7 @@ struct QBankUiState {
     // Error -- scoped per concern so filter errors don't leak to home screen
     var error: String? = nil
     var filterError: String? = nil
+    var answerError: String? = nil
 
     // MARK: - Computed
 
@@ -207,11 +208,21 @@ final class QBankViewModel {
 
     // MARK: - Home
 
+    /// Slugify enrolled subject names into discipline slugs that the backend
+    /// resolves (exact / alias / token-trim) against qbank_topics.disciplineSlug.
+    /// e.g. "Patologia Medica" -> "patologia-medica" -> canonical "patologia-geral".
+    var enrolledDisciplineSlugs: [String] {
+        let all = (dataManager.gradesResponse?.current ?? []) + (dataManager.gradesResponse?.completed ?? [])
+        let slugs = all.map { Self.slugifyDisciplineTitle($0.subjectName) }.filter { !$0.isEmpty }
+        return Array(Set(slugs)).sorted()
+    }
+
     func loadHomeData() {
         Task {
             state.progressLoading = true
             do {
-                async let progressTask = api.getQBankProgress()
+                let slugs = enrolledDisciplineSlugs
+                async let progressTask = api.getQBankProgress(disciplineSlugs: slugs)
                 async let sessionsTask = api.getQBankSessions(limit: 5)
                 state.progress = try await progressTask
                 let sessionsResponse = try? await sessionsTask
@@ -567,18 +578,22 @@ final class QBankViewModel {
                 sessionId: state.session?.id
             )
             var result: QBankAnswerResponse?
+            var lastError: Error?
             // Try up to 2 times (initial + 1 retry)
             for attempt in 0..<2 {
                 do {
                     result = try await api.answerQBankQuestion(id: question.id, request: request)
+                    lastError = nil
                     break
                 } catch {
+                    lastError = error
                     if attempt == 0 {
                         try? await Task.sleep(for: .milliseconds(500))
                     }
                 }
             }
             if let result {
+                state.answerError = nil
                 state.answerResult = result
                 state.sessionAnswers[question.id] = result
                 state.showFeedback = true
@@ -589,7 +604,11 @@ final class QBankViewModel {
                     }
                 }
             } else {
-                // Fallback to local calculation
+                // Surface the real error to the UI instead of silently faking success.
+                // Local fallback keeps the session moving but we flag it so the student
+                // knows the answer didn't reach the server (progress won't persist).
+                print("[QBank] confirmAnswer failed after retry: \(String(describing: lastError))")
+                state.answerError = "N\u{e3}o consegui registrar sua resposta no servidor. Sua sess\u{e3}o continua, mas esta quest\u{e3}o pode n\u{e3}o aparecer no progresso."
                 let isCorrect = question.alternatives.first(where: { $0.id == alternativeId })?.isCorrect ?? false
                 let fallback = QBankAnswerResponse(isCorrect: isCorrect, answerId: 0)
                 state.answerResult = fallback


### PR DESCRIPTION
## Summary

Three stacked iOS pieces landing together so the QBank Home screen finally shows the student's real discipline-scoped data instead of the misleading 0/95.424 global count:

- **PR2b** (1a87a1f) — wire iOS models to PR#90 backend schema (disciplineSlugs/titles)
- **PR2c** (31d39ba) — Hero redesign replicating Faculdade pattern + enrolled-scope wiring + auto-nav to Disciplinas when empty
- **PR2d** (31d39ba) — SessionCard pt_BR dates, title fallback, honest meta line + confirmAnswer error banner

## Hero (QBankProgressHero — full rewrite)

- ZStack with `heroSolidBackground` (dark vertical gradient 0.10→0.05 warm brown) + `heroGoldAccent` (radial top-right) + `heroQuestionMotif` (`questionmark.square.fill` 64pt ultraLight topTrailing 0.08 opacity) + `heroContent`
- 162pt height, 18pt corner, gold gradient stroke `[0.40, 0.10, 0.25]` lineWidth 1
- Shadow black 0.30 radius 14 y 6 — identical to Faculdade hero
- Eyebrow "SUAS DISCIPLINAS" + big `formatNumber(totalAnswered) / formatNumber(totalAvailable)` monospacedDigit
- Stats strip: Disciplinas | Respondidas | Acerto%

## Enrolled scope

- `QBankViewModel.enrolledDisciplineSlugs` slugifies `dataManager.gradesResponse.current + completed` via the existing `slugifyDisciplineTitle`
- `loadHomeData()` now calls `getQBankProgress(disciplineSlugs:)` with those slugs
- Backend (vitaai-web #90, already on main at `fdf9b7c`) resolves raw slugs like `patologia-medica` → canonical `patologia-geral` via exact/alias/token-trim
- **Verified E2E**: Rafael's 8 enrolled slugs → 7 canonical → **5.463 questões** (not 95.424)

## Auto-nav when empty

`QBankHomeContent.onChange(of: progressLoading)` — if `totalAvailable == 0 && recentSessions.isEmpty` after first load, pushes Disciplinas so the screen never shows an empty lie.

## SessionCard

- `formatRelative(createdAt)` parses ISO8601 (with/without fractional seconds), returns **"hoje HH:mm"** / **"ontem HH:mm"** / **"dd MMM HH:mm"** in pt_BR
- Title fallback chain: `session.title` → `disciplineTitles.first` (+N suffix for multi) → "Sessão de N questões"
- Meta line: `"X/Y · N% · when"` for completed, `"idx/total · when"` + chevron for active (no more fake 0%)

## confirmAnswer hardening

`state.answerError` surfaces a red banner in `QBankSessionContent` when the API round-trip fails twice, replacing the previous silent local-fallback. The session still progresses so the student isn't blocked, but they're told the answer didn't reach the server.

## Test plan

- [x] Backend E2E: `curl '…/api/qbank/progress?disciplineSlugs[]=patologia-medica&…'` returns `totalAvailable: 5463`, `scope: "enrolled"`
- [x] iOS build green on iPhone 17 Pro (dev-sim.sh, 2026-04-18 00:32)
- [x] Pre-commit xcodebuild hook passes
- [ ] Visual QA in sim: Hero matches Faculdade pattern with enrolled totals
- [ ] Visual QA: Session card shows "hoje HH:mm" for a session created today
- [ ] Manual: trigger confirmAnswer failure (airplane mode) and see the red banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)