### PR TITLE
refactor(router): single source of truth via AppState enum

### DIFF
--- a/VitaAI/Core/Auth/TokenStore.swift
+++ b/VitaAI/Core/Auth/TokenStore.swift
@@ -11,8 +11,6 @@ actor TokenStore {
         static let userName = "vita_user_name"
         static let userEmail = "vita_user_email"
         static let userImage = "vita_user_image"
-        static let isOnboarded = "vita_is_onboarded"
-        static let legacyIsOnboarded = "vita_onboarding_done"
         static let onboardingNickname = "vita_onboarding_nickname"
         static let onboardingUniversity = "vita_onboarding_university"
         static let onboardingState = "vita_onboarding_state"
@@ -36,12 +34,8 @@ actor TokenStore {
         token != nil
     }
 
-    var isOnboarded: Bool {
-        #if DEBUG
-        if AppConfig.ciToken != nil { return true }
-        #endif
-        return AppConfig.isOnboardingComplete(in: defaults)
-    }
+    // NOTE: There is intentionally no `isOnboarded` here. Backend is the single
+    // source of truth via /api/profile — see AppRouter.AppState.
 
     // MARK: - User Info (Keychain-backed)
 
@@ -88,10 +82,10 @@ actor TokenStore {
         keychain.delete(key: Keys.userName)
         keychain.delete(key: Keys.userEmail)
         keychain.delete(key: Keys.userImage)
-        // Clear UserDefaults (onboarding + legacy)
+        // Clear UserDefaults (onboarding cached fields; backend flag is server-side)
         let keysToRemove = [
             Keys.userName, Keys.userEmail, Keys.userImage,
-            Keys.isOnboarded, Keys.legacyIsOnboarded, Keys.onboardingNickname, Keys.onboardingUniversity,
+            Keys.onboardingNickname, Keys.onboardingUniversity,
             Keys.onboardingState, Keys.onboardingSemester, Keys.onboardingSubjects,
             Keys.onboardingGoals, Keys.onboardingDailyMinutes
         ]
@@ -103,7 +97,8 @@ actor TokenStore {
     // MARK: - Onboarding
 
     func saveOnboardingData(_ data: OnboardingData) {
-        AppConfig.setOnboardingComplete(true, in: defaults)
+        // Backend is the source of truth for onboardingCompleted (see postOnboarding).
+        // We only cache the raw fields locally for offline read-back / prefill.
         defaults.set(data.nickname, forKey: Keys.onboardingNickname)
         defaults.set(data.universityName, forKey: Keys.onboardingUniversity)
         defaults.set(data.universityState, forKey: Keys.onboardingState)

--- a/VitaAI/Core/Config/AppConfig.swift
+++ b/VitaAI/Core/Config/AppConfig.swift
@@ -12,9 +12,6 @@ enum AppConfig {
     static let environment: AppEnvironment = .production
     #endif
 
-    static let onboardingKey = "vita_is_onboarded"
-    static let legacyOnboardingKey = "vita_onboarding_done"
-
     // DEBUG builds hit the dev server on monstro via Tailscale (hot-reload backend).
     // Release builds (TestFlight / App Store) hit production vita-ai.cloud — the
     // tester's device cannot depend on Rafael's PC being online / Tailscale connected.
@@ -109,10 +106,6 @@ enum AppConfig {
         return defaultAuthBaseURL
     }
 
-    static var shouldResetOnboarding: Bool {
-        hasLaunchFlag("--reset-onboarding", defaultsKey: "vita_reset_onboarding", envKey: "VITA_RESET_ONBOARDING")
-    }
-
     static var injectedSession: InjectedSession? {
         let arguments = ProcessInfo.processInfo.arguments
         guard let idx = arguments.firstIndex(of: "--vita-inject-token"),
@@ -148,15 +141,6 @@ enum AppConfig {
             return explicit
         }
         return url.host
-    }
-
-    static func isOnboardingComplete(in defaults: UserDefaults = .standard) -> Bool {
-        defaults.bool(forKey: onboardingKey) || defaults.bool(forKey: legacyOnboardingKey)
-    }
-
-    static func setOnboardingComplete(_ value: Bool, in defaults: UserDefaults = .standard) {
-        defaults.set(value, forKey: onboardingKey)
-        defaults.set(value, forKey: legacyOnboardingKey)
     }
 
     static var sessionCookieName: String {

--- a/VitaAI/Features/Onboarding/VitaOnboarding.swift
+++ b/VitaAI/Features/Onboarding/VitaOnboarding.swift
@@ -473,8 +473,10 @@ struct VitaOnboarding: View {
 
     private func saveOnboarding() async {
         guard let vm = viewModel else { return }
+        // Backend is the single source of truth. vm.complete() POSTs to
+        // /api/profile onboardingCompleted=true; AppRouter re-derives state
+        // from the fresh profile — no client-side flag needed.
         await vm.complete()
-        AppConfig.setOnboardingComplete(true)
     }
 
     private func requestNotificationPermission() {

--- a/VitaAI/Navigation/AppRouter.swift
+++ b/VitaAI/Navigation/AppRouter.swift
@@ -66,87 +66,54 @@ private struct NavControllerBackgroundClearer: UIViewRepresentable {
     }
 }
 
+/// Single source of truth for top-level app routing.
+///
+/// Derived exclusively from (authManager.isLoggedIn × /api/profile response).
+/// NO UserDefaults flags. NO @AppStorage. Backend is authority.
+enum AppState: Equatable {
+    case loading
+    case unauthenticated
+    case onboardingNeeded
+    case ready
+}
+
 struct AppRouter: View {
     @ObservedObject var authManager: AuthManager
     @Environment(\.appContainer) private var container
-    @AppStorage("vita_is_onboarded") private var isOnboardedStored = false
-    @AppStorage("vita_onboarding_done") private var legacyOnboardingStored = false
     @State private var router = Router()
-    @State private var profileChecked = false
-    @State private var needsOnboarding = false
+    @State private var appState: AppState = .loading
 
     var body: some View {
         Group {
-            if authManager.isLoading || (authManager.isLoggedIn && !profileChecked) {
-                // Show loading while auth is initializing OR profile check is pending.
-                // CRITICAL: do NOT show MainTabView before profileChecked — it fires
-                // background API calls (gamification, subscriptions) that can 401 and
-                // trigger global logout before onboarding even starts.
+            switch appState {
+            case .loading:
                 ZStack {
                     VitaColors.surface.ignoresSafeArea()
-                    ProgressView()
-                        .tint(VitaColors.accent)
+                    ProgressView().tint(VitaColors.accent)
                 }
-            } else if !authManager.isLoggedIn {
+            case .unauthenticated:
                 LoginScreen(authManager: authManager)
-            } else if needsOnboarding {
+            case .onboardingNeeded:
                 VitaOnboarding(
                     userName: authManager.userName ?? "",
-                    onLogout: {
-                        Task { await authManager.logout() }
-                    }
+                    onLogout: { Task { await authManager.logout() } }
                 ) {
-                    isOnboardedStored = true
-                    legacyOnboardingStored = true
-                    needsOnboarding = false
+                    // Onboarding completion writes to backend (postOnboarding).
+                    // Re-derive state from fresh profile — backend is authority.
+                    Task { await refreshAppState() }
                 }
-            } else {
+            case .ready:
                 MainTabView(router: router, authManager: authManager)
             }
         }
+        .task(id: authManager.isLoading) {
+            // Wait for auth manager to finish initializing before deriving state.
+            if !authManager.isLoading {
+                await refreshAppState()
+            }
+        }
         .task(id: authManager.isLoggedIn) {
-            guard authManager.isLoggedIn else {
-                profileChecked = false
-                needsOnboarding = false
-                return
-            }
-            do {
-                let profile = try await container.api.getProfile()
-                NSLog("[AppRouter] getProfile OK onboardingCompleted=\(String(describing: profile.onboardingCompleted)) university=\(String(describing: profile.university))")
-                if profile.onboardingCompleted != true {
-                    needsOnboarding = true
-                    isOnboardedStored = false
-                    legacyOnboardingStored = false
-                } else {
-                    needsOnboarding = false
-                    isOnboardedStored = true
-                }
-            } catch let error as APIError {
-                // 401 = token expired — let the global handler deal with it,
-                // but do NOT set needsOnboarding (we're about to be logged out).
-                if case .unauthorized = error {
-                    NSLog("[AppRouter] getProfile 401 — token expired, logout imminent")
-                    profileChecked = true
-                    return
-                }
-                if case .serverError(404) = error {
-                    // 404 = no profile exists = genuinely needs onboarding
-                    needsOnboarding = true
-                    isOnboardedStored = false
-                    legacyOnboardingStored = false
-                } else {
-                    // Other API errors (500, decode, etc) — DON'T assume onboarding.
-                    // Show main tab and let normal error handling deal with it.
-                    NSLog("[AppRouter] getProfile API error (not 404): \(error) — skipping onboarding check")
-                    needsOnboarding = false
-                }
-            } catch {
-                // Network error / timeout — DON'T force onboarding.
-                // The user may be fully onboarded but temporarily offline.
-                NSLog("[AppRouter] getProfile network error: \(error) — skipping onboarding check")
-                needsOnboarding = false
-            }
-            profileChecked = true
+            await refreshAppState()
         }
         .preferredColorScheme(.dark)
         .onOpenURL { url in
@@ -178,10 +145,80 @@ struct AppRouter: View {
         }
     }
 
-
-    // Note: onboarding check is now fully handled by the `needsOnboarding` state
-    // set from the profile check in `.task(id:)`. The `isOnboardedStored` and
-    // `legacyOnboardingStored` flags are kept as fallback for offline launches.
+    /// Derives `appState` purely from auth + /api/profile response.
+    /// Backend is the single source of truth — no client-side flags.
+    @MainActor
+    private func refreshAppState() async {
+        if authManager.isLoading {
+            appState = .loading
+            return
+        }
+        guard authManager.isLoggedIn else {
+            appState = .unauthenticated
+            return
+        }
+        // Only show loading while we don't know yet. Otherwise keep the
+        // previous resolved state to avoid a flash.
+        if appState == .unauthenticated {
+            appState = .loading
+        }
+        do {
+            let profile = try await container.api.getProfile()
+            NSLog("[AppRouter] getProfile OK onboardingCompleted=\(String(describing: profile.onboardingCompleted)) university=\(String(describing: profile.university))")
+            SentryConfig.addBreadcrumb(
+                message: "getProfile OK",
+                category: "onboarding",
+                data: [
+                    "onboardingCompleted": profile.onboardingCompleted ?? false,
+                    "hasUniversity": profile.university != nil,
+                ]
+            )
+            appState = (profile.onboardingCompleted == true) ? .ready : .onboardingNeeded
+        } catch let error as APIError {
+            switch error {
+            case .unauthorized:
+                // Global 401 handler will trigger logout → authManager.isLoggedIn flips,
+                // the isLoggedIn task re-runs, and state becomes .unauthenticated.
+                NSLog("[AppRouter] getProfile 401 — awaiting logout")
+                SentryConfig.addBreadcrumb(message: "getProfile 401", category: "onboarding")
+            case .serverError(404):
+                // Truly no profile → onboarding.
+                NSLog("[AppRouter] getProfile 404 — onboarding needed")
+                SentryConfig.addBreadcrumb(message: "getProfile 404 → onboarding", category: "onboarding")
+                appState = .onboardingNeeded
+            case .decodingError(let decodeErr):
+                // Contract drift: report to Sentry and keep user on dashboard.
+                // NEVER hijack an authenticated session back to onboarding over a parse bug.
+                NSLog("[AppRouter] getProfile DECODE ERROR: \(decodeErr) — staying on dashboard")
+                SentryConfig.capture(
+                    error: decodeErr,
+                    context: ["endpoint": "/api/profile", "phase": "router-state-derivation"]
+                )
+                appState = .ready
+            default:
+                // Transient 500/network error — keep user on dashboard; screens
+                // handle missing data with their own empty/error states.
+                NSLog("[AppRouter] getProfile API error (transient): \(error) — staying on dashboard")
+                SentryConfig.capture(
+                    error: error,
+                    context: ["endpoint": "/api/profile", "phase": "router-state-derivation"]
+                )
+                if appState == .loading { appState = .ready }
+            }
+        } catch {
+            NSLog("[AppRouter] getProfile network error: \(error) — staying on dashboard")
+            SentryConfig.addBreadcrumb(
+                message: "getProfile network error",
+                category: "onboarding",
+                data: ["error": String(describing: error)]
+            )
+            if appState == .loading { appState = .ready }
+        }
+        SentryConfig.addBreadcrumb(
+            message: "appState = \(appState)",
+            category: "navigation"
+        )
+    }
 }
 
 struct MainTabView: View {

--- a/VitaAI/VitaAIApp.swift
+++ b/VitaAI/VitaAIApp.swift
@@ -187,9 +187,8 @@ private extension VitaAIApp {
         let defaults = UserDefaults.standard
         let keychain = KeychainHelper.shared
 
-        if AppConfig.shouldResetOnboarding {
-            AppConfig.setOnboardingComplete(false, in: defaults)
-        }
+        // Onboarding state is server-authoritative (/api/profile.onboardingCompleted).
+        // To reset, call the backend — never touch client UserDefaults for routing.
 
         if let injected = AppConfig.injectedSession {
             keychain.save(key: "vita_session_token", value: injected.token)


### PR DESCRIPTION
## Summary

Collapse 4 interlocking flags into a single backend-derived enum. Client no longer second-guesses server authority — to reset onboarding, update `/api/profile` server-side, never client UserDefaults.

**Before:** `@AppStorage vita_is_onboarded` + legacy `vita_onboarding_done` + `@State profileChecked` + `@State needsOnboarding` — four flags mutually reinforcing, five error branches, one network blip could dump an authenticated user back to onboarding.

**After:** `enum AppState { .loading, .unauthenticated, .onboardingNeeded, .ready }` derived exclusively from `authManager.isLoggedIn × /api/profile.onboardingCompleted`. `.task(id:)` reruns on auth change. 401 lets global logout fire. 404 → onboarding. Decode error → capture to Sentry, stay on dashboard (never hijack session). Transient 500/network → stay on dashboard.

## Files

- `VitaAI/Navigation/AppRouter.swift` — enum switch + `refreshAppState()` async helper
- `VitaAI/Core/Config/AppConfig.swift` — removed `onboardingKey`, `legacyOnboardingKey`, `shouldResetOnboarding`, `isOnboardingComplete`, `setOnboardingComplete`
- `VitaAI/Core/Auth/TokenStore.swift` — removed `Keys.isOnboarded`, `Keys.legacyIsOnboarded`, `isOnboarded` computed
- `VitaAI/VitaAIApp.swift` — removed UserDefaults reset shim in `bootstrapLaunchState`
- `VitaAI/Features/Onboarding/VitaOnboarding.swift` — removed post-complete client flag write

## Test plan

- [x] Build green (pre-commit hook ran `xcodebuild build`)
- [x] Sim launch — logged-out user sees welcome, completed-onboarding user routes directly to dashboard
- [ ] QA: onboarding flow still writes to backend via `postOnboarding`
- [ ] QA: 401 mid-session still logs user out (no dump to onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)