### PR TITLE
fix(qbank): unify Nova Sessão with Home glass amber

### DIFF
--- a/VitaAI/Features/QBank/QBankConfigContent.swift
+++ b/VitaAI/Features/QBank/QBankConfigContent.swift
@@ -171,32 +171,28 @@ struct QBankConfigContent: View {
     }
 
     private var availableCountBanner: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "doc.text.magnifyingglass")
-                .font(.system(size: 14))
-                .foregroundStyle(VitaColors.accent)
-            if vm.state.isLoadingCount {
-                ProgressView()
-                    .tint(VitaColors.accent)
-                    .scaleEffect(0.7)
-                Text("Calculando...")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(VitaColors.textSecondary)
-            } else {
-                Text("\(formatNumber(vm.state.displayAvailableCount)) questões disponíveis")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(VitaColors.accentLight)
+        VitaGlassCard(cornerRadius: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.system(size: 14))
+                    .foregroundStyle(VitaColors.accent)
+                if vm.state.isLoadingCount {
+                    ProgressView()
+                        .tint(VitaColors.accent)
+                        .scaleEffect(0.7)
+                    Text("Calculando...")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(VitaColors.textSecondary)
+                } else {
+                    Text("\(formatNumber(vm.state.displayAvailableCount)) questões disponíveis")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(VitaColors.accentLight)
+                }
+                Spacer()
             }
-            Spacer()
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(VitaColors.accent.opacity(0.06))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(VitaColors.accent.opacity(0.15), lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     private var questionCountSection: some View {
@@ -390,7 +386,7 @@ struct QBankConfigContent: View {
                 }
                 .padding(.vertical, 12)
             } else {
-                // Count + button
+                // Count + themed CTA (matches Home "Nova Sessão" glass amber)
                 HStack {
                     if vm.state.isLoadingCount {
                         ProgressView()
@@ -405,9 +401,11 @@ struct QBankConfigContent: View {
                 }
                 .padding(.horizontal, 16)
 
-                VitaButton(
-                    text: "Iniciar Sessão (\(vm.state.questionCount) questões)",
-                    action: { vm.createSession() }
+                StudyShellCTA(
+                    title: "Iniciar Sessão (\(vm.state.questionCount) questões)",
+                    theme: .questoes,
+                    action: { vm.createSession() },
+                    systemImage: "play.fill"
                 )
                 .padding(.horizontal, 16)
             }
@@ -638,20 +636,16 @@ struct QBankConfigContent: View {
     // MARK: - Helpers
 
     private func configGlassSection(title: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(title)
-                .font(.system(size: 11, weight: .bold))
-                .tracking(0.8)
-                .foregroundStyle(VitaColors.sectionLabel)
-            content()
+        VitaGlassCard(cornerRadius: 14) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.system(size: 11, weight: .bold))
+                    .tracking(0.8)
+                    .foregroundStyle(VitaColors.sectionLabel)
+                content()
+            }
+            .padding(14)
         }
-        .padding(14)
-        .background(VitaColors.glassBg)
-        .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(VitaColors.glassBorder, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 14))
     }
 
     private func formatNumber(_ n: Int) -> String {


### PR DESCRIPTION
## What

Rafael tapped Nova Sessão and saw flat black section backgrounds + solid amber CTA button. He said 'botões pretos bem feios'. QBank Home uses `VitaGlassCard` (3-layer warm glass) + `StudyShellCTA` (glass + amber gradient). This PR brings the config screen to the same system.

## Changes (1 file, 35 insertions, 41 deletions)

`VitaAI/Features/QBank/QBankConfigContent.swift`:

1. **\`configGlassSection\` helper** — wraps in `VitaGlassCard(cornerRadius: 14)` instead of flat `VitaColors.glassBg` + plain stroke. Every questionCount/difficulty/year/mode section now has the warm radial glow + conic gold border.

2. **\`availableCountBanner\`** — `VitaGlassCard(cornerRadius: 12)` backdrop, keeping the amber `doc.text.magnifyingglass` icon + `accentLight` text. Banner now reads as depth, not a colored block.

3. **Bottom CTA \"Iniciar Sessão\"** — replaces `VitaButton(.primary)` (solid amber fill) with `StudyShellCTA(theme: .questoes, systemImage: \"play.fill\")`. Matches the Nova Sessão button on QBank Home exactly: `.ultraThinMaterial` base + amber gradient wash + inner top highlight + amber drop shadow.

No schema, no behavior, no new components.

## Verification

- ✅ Pre-commit hook: `xcodebuild BUILD SUCCEEDED`
- ⚠️ Live sim screenshot blocked by SpringBoard notification dialog (requires computer-use access to tap Permitir; Rafael sleeping, cannot approve)

## Test plan

- [ ] Tap Questões → Nova Sessão
- [ ] Verify sections no longer look flat black
- [ ] Verify \"Iniciar Sessão\" CTA matches Nova Sessão button on Home (amber glass)
- [ ] Confirm no regression in picker sheets (institution/topic)

Related audit: \`agent-brain/qbank-audit-2026-04-20.md\`
Backend PR: by-mav/vitaai-web#109 (c3c66a8)