### PR TITLE
feat(onboarding): ExtrasStep — WhatsApp + Drive + Calendar + Spotify

### DIFF
--- a/VitaAI.xcodeproj/project.pbxproj
+++ b/VitaAI.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		1C521DD85F499EB9BF652087 /* VitaFloatingMascot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7CE8DC3286060EA68C2FA4 /* VitaFloatingMascot.swift */; };
 		1C7533B53F1EF40CDEB93062 /* MindMapCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB1D136E9C8BF95B31996F5 /* MindMapCanvasView.swift */; };
 		1CBE123A1645C745890556BB /* WebAlunoModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC72C759C5834DA94FD4AD5 /* WebAlunoModels.swift */; };
+		1EC9252E3580C6E7F3A8EFA6 /* AgendaScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DA2E5AB94A967BC20FEAE0 /* AgendaScreen.swift */; };
 		2095E3FD39E761A5EB7AA12D /* SilentPortalSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314297A0A778A73D82243DDC /* SilentPortalSync.swift */; };
 		2140848C8036F14D7D28F581 /* LocalModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CC1451A7DEAC45439CDEE8 /* LocalModels.swift */; };
 		2149E1761AFC39A3D2A71936 /* VitaAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4DE24CBF4DF36D7893CE6A /* VitaAPI.swift */; };
@@ -92,6 +93,7 @@
 		38735D1BB10023AA90F40D77 /* StudyOverviewFlashcards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDC2690C2FD02E700F634E6 /* StudyOverviewFlashcards.swift */; };
 		38AACF18344AF1B31B41ACE7 /* MannesoftCookieStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56CFB53F2B1028C931B5BBD /* MannesoftCookieStore.swift */; };
 		38C16C9ADD318E2625BC36ED /* InsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75E96FF57B89B2EE5967448 /* InsightsViewModel.swift */; };
+		39385C5B0814FF112278FF51 /* OnboardingWhatsAppLinkSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6755C4D9337DD81D33B0469 /* OnboardingWhatsAppLinkSheet.swift */; };
 		39472E20831D493CC43D2BE5 /* PaywallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56845E72F3F2F9B9857BA4F8 /* PaywallScreen.swift */; };
 		3CEBF87D5DD3BF842B3ABD91 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C706FF6BED2501FA53B24F /* Profile.swift */; };
 		3DB8FA5F571CDAC78653759B /* SleepStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41A461824D7C6411A6B64725 /* SleepStep.swift */; };
@@ -267,6 +269,7 @@
 		CA428A9C95ECDAA42F7CE362 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B18EC14C18BD1A28685ADF2 /* HTTPClient.swift */; };
 		CA8C4DBCF2E36CED72C5C8EB /* LoginScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ACE155F51ED39EBBE513B7 /* LoginScreen.swift */; };
 		CADC05294F3B256F8E69599D /* SimuladoConfigScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37003CEC2FA82479AA0037DE /* SimuladoConfigScreen.swift */; };
+		CAFC22F70859BC5E8856DE49 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 58B636EDE3D2FC8F4C739405 /* PrivacyInfo.xcprivacy */; };
 		CBDB52325B789D01A697EBAE /* EmailAuthSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8FE94587B7F5721A573CFB /* EmailAuthSheet.swift */; };
 		CD764114E07D347F8DF2A44D /* OsceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9EFD803AA3823BCDAB4F04 /* OsceScreen.swift */; };
 		CDC626FD70D21814D55D60EC /* VitaBreadcrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032B7F8C0B61415B9E30313 /* VitaBreadcrumb.swift */; };
@@ -290,10 +293,8 @@
 		DD418FDA220081A89C78B51E /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDFDAD7DC6888C96464781E /* FlowLayout.swift */; };
 		DD54025EF50E0E5227E2CAB4 /* RetentionChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A89A1B0CCEDB9EF3722420 /* RetentionChartView.swift */; };
 		DEBC36D19EA98D5B4B2B297A /* VitaAmbientBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1130013BF0504A0F42C04360 /* VitaAmbientBackground.swift */; };
-		DEC57FCEEC784BFABCDE28D1 /* AgendaScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9FFC0C65AB46CCB8C56080 /* AgendaScreen.swift */; };
 		DECDA0E1A8B2FD483D001ACC /* CanvasSyncOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC6A00C517673F53DDAA5A /* CanvasSyncOrchestrator.swift */; };
 		E032B7AB430B778EB2CC814E /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = BE8487C3CD50772214487973 /* Sentry */; };
-		E05F7C2514518637743B31B7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EC8DDA9180557E4FF75C1BD0 /* PrivacyInfo.xcprivacy */; };
 		E06056BD261CF86083640CC2 /* ScreenshotAllTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8846B84EB4BB6E8296E2C099 /* ScreenshotAllTabs.swift */; };
 		E0A65FE7D1902E9547EDEA95 /* SwipeBackGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDAA413F2758CCA0283E9C /* SwipeBackGesture.swift */; };
 		E0BDC0DABF96620D39D576EE /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF6BA038BDF0C52FCB0549B /* TokenStore.swift */; };
@@ -305,11 +306,12 @@
 		E498180A7AF2942286123C91 /* GamificationOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B6383885FE4CA9D45C9592 /* GamificationOverlays.swift */; };
 		E529109D0803E34CB4DC0B2D /* MindMapListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6487870DA0185F897228C92 /* MindMapListViewModel.swift */; };
 		E9CB954DF22CC9B832B690FD /* ConnectorsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C06511C1120C3D564023F3 /* ConnectorsViewModel.swift */; };
-		EBAD5D7A4F0347FA8240EF9B /* VitaHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A461F9DC20E84DA3A650A0B7 /* VitaHeroCard.swift */; };
 		ED4FCA6A681400D2B2E82598 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E96A2F8EC619718B744BFD6 /* APIError.swift */; };
 		ED940D904DE51599BECDDBF3 /* TranscricaoProfessorSignals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195A69CD6776A957B920D6E0 /* TranscricaoProfessorSignals.swift */; };
 		EDD8F6E728065C3FF6BDE691 /* VitaMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84201C4AE38526C62B3DFD1 /* VitaMarkdown.swift */; };
+		EE4792714534A3C5D8C30E30 /* VitaHeroCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0A672CEFBE535AB4832CC /* VitaHeroCard.swift */; };
 		EFCBB59972C369F34DED0E8F /* VitaChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9303E2BEC94F1B5C9607C134 /* VitaChatScreen.swift */; };
+		F26A1A794273B9DAC041774D /* ExtrasStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547830FC76948B3C5AB77457 /* ExtrasStep.swift */; };
 		F364B8A8FDCFCA606C0693FF /* VideoBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBCCFEE392F9CB2615DF85D8 /* VideoBackground.swift */; };
 		F53094AF37BB3E9E9FE76CEA /* PdfViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543196E867D0B232733BEA7D /* PdfViewerViewModel.swift */; };
 		F65ADD5040E49D99716358D7 /* GlassAuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4115858B2E1C1E3408712051 /* GlassAuthButton.swift */; };
@@ -442,11 +444,13 @@
 		541E22A09857C9F160E0E617 /* VitaBadgeGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaBadgeGrid.swift; sourceTree = "<group>"; };
 		543196E867D0B232733BEA7D /* PdfViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerViewModel.swift; sourceTree = "<group>"; };
 		543CE1745019B2263757A4AF /* LeaderboardScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardScreen.swift; sourceTree = "<group>"; };
+		547830FC76948B3C5AB77457 /* ExtrasStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtrasStep.swift; sourceTree = "<group>"; };
 		54C5921B1E7D6773BE496440 /* ProgressoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressoViewModel.swift; sourceTree = "<group>"; };
 		5513CD19D0230B41AC440E8D /* NotebookStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStore.swift; sourceTree = "<group>"; };
 		564E8E7192471F3F1E0AD40A /* QBankCoordinatorScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QBankCoordinatorScreen.swift; sourceTree = "<group>"; };
 		56845E72F3F2F9B9857BA4F8 /* PaywallScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallScreen.swift; sourceTree = "<group>"; };
 		587035BC7D829951519C0696 /* FaculdadeDisciplinasScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaculdadeDisciplinasScreen.swift; sourceTree = "<group>"; };
+		58B636EDE3D2FC8F4C739405 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		592B63FA996C5A6E62A174DE /* VitaSubTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaSubTabBar.swift; sourceTree = "<group>"; };
 		5A45516BBF7E16BFB9410B27 /* AppRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRouter.swift; sourceTree = "<group>"; };
 		5D545B4D23872BE2BD3194EF /* FaculdadeMateriasScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaculdadeMateriasScreen.swift; sourceTree = "<group>"; };
@@ -537,7 +541,6 @@
 		A1611D36BC820AF3CB70BD36 /* StudyOverviewSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyOverviewSubject.swift; sourceTree = "<group>"; };
 		A20A68F955FFD87D1B3A1BE0 /* NotebookModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookModels.swift; sourceTree = "<group>"; };
 		A2D2ABE74986AE1F7A75D3FA /* NotebookEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookEntity.swift; sourceTree = "<group>"; };
-		A461F9DC20E84DA3A650A0B7 /* VitaHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaHeroCard.swift; sourceTree = "<group>"; };
 		A4F671C3A0DA731099C2B38F /* AssinaturaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssinaturaScreen.swift; sourceTree = "<group>"; };
 		A64B7AFF614D70112CC3B1D8 /* CourseDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailViewModel.swift; sourceTree = "<group>"; };
 		A75E96FF57B89B2EE5967448 /* InsightsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsViewModel.swift; sourceTree = "<group>"; };
@@ -552,6 +555,7 @@
 		AE820FA12745A79A71139683 /* VitaStreakBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaStreakBadge.swift; sourceTree = "<group>"; };
 		AF202C03ABE82B48CB9E87A3 /* OsceResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsceResultView.swift; sourceTree = "<group>"; };
 		AFE40A55E0A9E836E6DC890A /* Color+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
+		B1A0A672CEFBE535AB4832CC /* VitaHeroCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaHeroCard.swift; sourceTree = "<group>"; };
 		B1B869512A09C99A6DCF4177 /* DeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandler.swift; sourceTree = "<group>"; };
 		B26F29C8F6797062934D4D8F /* NotebookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookListViewModel.swift; sourceTree = "<group>"; };
 		B39730C4459D428670423B22 /* CrowdModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdModels.swift; sourceTree = "<group>"; };
@@ -605,6 +609,7 @@
 		D431F9DA5C56FB16C57122FE /* QBankHomeContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QBankHomeContent.swift; sourceTree = "<group>"; };
 		D5927902FF9A582D530AC326 /* FlashcardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardCard.swift; sourceTree = "<group>"; };
 		D8562D147AB3395719D9F977 /* EmailAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAuthViewModel.swift; sourceTree = "<group>"; };
+		D8DA2E5AB94A967BC20FEAE0 /* AgendaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgendaScreen.swift; sourceTree = "<group>"; };
 		DA88B383AB1A6C7CDD0DAD1F /* MonthlyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyCalendarView.swift; sourceTree = "<group>"; };
 		DB684A334A59A093C00DB8EC /* VitaAIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaAIApp.swift; sourceTree = "<group>"; };
 		DB91BBC40C1F6D63A5607E71 /* VoiceModeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceModeViewModel.swift; sourceTree = "<group>"; };
@@ -618,18 +623,17 @@
 		E3E4C62B51093D4EC3F94246 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E405E8F265D5EC67BC3497E8 /* Route+Breadcrumb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Breadcrumb.swift"; sourceTree = "<group>"; };
 		E64F3F466E1AEC167C8E16C4 /* InsightsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsScreen.swift; sourceTree = "<group>"; };
+		E6755C4D9337DD81D33B0469 /* OnboardingWhatsAppLinkSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWhatsAppLinkSheet.swift; sourceTree = "<group>"; };
 		E6EFEEFBA17AF37F355A4848 /* PdfToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfToolbar.swift; sourceTree = "<group>"; };
 		E70BF1F2E97BAFB99CB82BAA /* SentryConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryConfig.swift; sourceTree = "<group>"; };
 		E8B8F6A0A39DA9F089559142 /* StudyShellTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyShellTheme.swift; sourceTree = "<group>"; };
 		E924DCF6AA655A4D83A473DD /* VitaMascot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaMascot.swift; sourceTree = "<group>"; };
-		EC8DDA9180557E4FF75C1BD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		EC8FE94587B7F5721A573CFB /* EmailAuthSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAuthSheet.swift; sourceTree = "<group>"; };
 		ECA6A8C8C58763ADD42697C2 /* GradeAlertMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeAlertMeta.swift; sourceTree = "<group>"; };
 		ED0343F16BF93C40BA29E8D8 /* AboutScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutScreen.swift; sourceTree = "<group>"; };
 		ED8EF772B3F18F7D47F42DB0 /* FlashcardSessionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardSessionScreen.swift; sourceTree = "<group>"; };
 		EDB92BC16796C4B64D408AF8 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		EE5394B30AB656D1D85DF9FD /* PortalFilterFiles200Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalFilterFiles200Response.swift; sourceTree = "<group>"; };
-		EE9FFC0C65AB46CCB8C56080 /* AgendaScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AgendaScreen.swift; path = VitaAI/Features/Agenda/AgendaScreen.swift; sourceTree = SOURCE_ROOT; };
 		EEC63CEAFB878B94BBCE32D8 /* VitaNotificationSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitaNotificationSheet.swift; sourceTree = "<group>"; };
 		EF8A54B9484818C1A97D4814 /* RegisterPushTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushTokenRequest.swift; sourceTree = "<group>"; };
 		F1D1E6D867F79AAC73B53994 /* SpeechRecognitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionManager.swift; sourceTree = "<group>"; };
@@ -668,6 +672,7 @@
 			children = (
 				8F5D2349C35D3C9097489379 /* ConnectStep.swift */,
 				9CFD863579290BBEF37373EC /* DoneStep.swift */,
+				547830FC76948B3C5AB77457 /* ExtrasStep.swift */,
 				CC2CEACE238BB315B6B8609E /* NotificationsStep.swift */,
 				41A461824D7C6411A6B64725 /* SleepStep.swift */,
 				4EB6BF61CB525B0164B5BD4B /* SubjectsStep.swift */,
@@ -795,9 +800,8 @@
 				CABC58C8177E84A757D6500E /* VitaErrorState.swift */,
 				BF7CE8DC3286060EA68C2FA4 /* VitaFloatingMascot.swift */,
 				231B6498AE9ECCFB21DB6A6E /* VitaGlassCard.swift */,
-				EE9FFC0C65AB46CCB8C56080 /* AgendaScreen.swift */,
-				A461F9DC20E84DA3A650A0B7 /* VitaHeroCard.swift */,
 				52357B3D17605B471E697E1C /* VitaHandle.swift */,
+				B1A0A672CEFBE535AB4832CC /* VitaHeroCard.swift */,
 				37569ED0C0303F076543301E /* VitaInput.swift */,
 				C84201C4AE38526C62B3DFD1 /* VitaMarkdown.swift */,
 				9F70F963371379D809067BD4 /* VitaMenuPopout.swift */,
@@ -935,6 +939,7 @@
 			children = (
 				E3E4C62B51093D4EC3F94246 /* Assets.xcassets */,
 				8E39BA8A7A69BB0E96E34197 /* Info.plist */,
+				58B636EDE3D2FC8F4C739405 /* PrivacyInfo.xcprivacy */,
 				414DC4C0D7872C5C3704CC51 /* VitaAI.entitlements */,
 				BBA019CD302ADAC93CAC7F13 /* VitaAI.storekit */,
 				DB684A334A59A093C00DB8EC /* VitaAIApp.swift */,
@@ -947,7 +952,6 @@
 				F67298E3C7A450E1CD520258 /* Models */,
 				D51A6B06E3096EFDF08669C5 /* Navigation */,
 				F8C24BEF44E7DACF462987FD /* Resources */,
-				EC8DDA9180557E4FF75C1BD0 /* PrivacyInfo.xcprivacy */,
 			);
 			path = VitaAI;
 			sourceTree = "<group>";
@@ -966,6 +970,7 @@
 			children = (
 				CD1F97052F42A7CD246E98D9 /* Achievements */,
 				17B4A4AA03830926DDD5DC08 /* Activity */,
+				A703595B5D4A7F62B23BD051 /* Agenda */,
 				E49B6A2236E62DB112EE89CF /* Atlas */,
 				22DD7A207D7C54681DAFF65D /* Auth */,
 				B641C6A7E08F2C888119E474 /* Billing */,
@@ -1013,6 +1018,7 @@
 				B65D0328992219B07CBDCF14 /* OnboardingConnectSheet.swift */,
 				1B21F86395E0A3E7867AFB51 /* OnboardingShared.swift */,
 				6B2FBDF30C2F0A96A7EA33EA /* OnboardingViewModel.swift */,
+				E6755C4D9337DD81D33B0469 /* OnboardingWhatsAppLinkSheet.swift */,
 				E924DCF6AA655A4D83A473DD /* VitaMascot.swift */,
 				6A6BBDE731EBEA07A41B98E5 /* VitaOnboarding.swift */,
 				0106322E52F1CC32508AE39D /* Steps */,
@@ -1201,6 +1207,14 @@
 				8C749E050E8D8D8822CB816D /* AppConfig.swift */,
 			);
 			path = Config;
+			sourceTree = "<group>";
+		};
+		A703595B5D4A7F62B23BD051 /* Agenda */ = {
+			isa = PBXGroup;
+			children = (
+				D8DA2E5AB94A967BC20FEAE0 /* AgendaScreen.swift */,
+			);
+			path = Agenda;
 			sourceTree = "<group>";
 		};
 		B641C6A7E08F2C888119E474 /* Billing */ = {
@@ -1485,6 +1499,8 @@
 				3F7FD2A6B35DB3CF75D10AF9 /* PBXTargetDependency */,
 			);
 			name = VitaAIUITests;
+			packageProductDependencies = (
+			);
 			productName = VitaAIUITests;
 			productReference = 71A803CD05ACDB97E5A85BD7 /* VitaAIUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -1563,8 +1579,8 @@
 			files = (
 				C1ED533F060E9256EA81DB91 /* Assets.xcassets in Resources */,
 				A9660EB0D2F93B27F63FD890 /* Localizable.strings in Resources */,
+				CAFC22F70859BC5E8856DE49 /* PrivacyInfo.xcprivacy in Resources */,
 				89E5E213E3113C09A90A1775 /* VitaAI.storekit in Resources */,
-				E05F7C2514518637743B31B7 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1591,6 +1607,7 @@
 				28E2FA2F1ED48B82D36736B1 /* ActivityFeedScreen.swift in Sources */,
 				744B59A0953409788797B5A3 /* ActivityFeedViewModel.swift in Sources */,
 				5FA5F1D86DDFC8917A2F9C98 /* ActivityModels.swift in Sources */,
+				1EC9252E3580C6E7F3A8EFA6 /* AgendaScreen.swift in Sources */,
 				8288F09531C36C728BFBE8A1 /* AnnotationEntity.swift in Sources */,
 				3F8C8E52B328962403D82247 /* AppConfig.swift in Sources */,
 				5FB79FC460A136B856EF3033 /* AppConfigResponse.swift in Sources */,
@@ -1659,6 +1676,7 @@
 				8107A559A4656C6B2522AA13 /* EstudosScreen.swift in Sources */,
 				0B365CDE13A4800E325112F4 /* EstudosViewModel.swift in Sources */,
 				4CD50558070536A9288C915A /* ExamUploadSheet.swift in Sources */,
+				F26A1A794273B9DAC041774D /* ExtrasStep.swift in Sources */,
 				415661B3051F6F606DF8CDBD /* FaculdadeDisciplinasScreen.swift in Sources */,
 				81B66187877A6E96C341E66C /* FaculdadeDocumentosScreen.swift in Sources */,
 				823D5C5A43B0CE111F2B2A87 /* FaculdadeHomeScreen.swift in Sources */,
@@ -1728,6 +1746,7 @@
 				4F9E9736A5C7F99EDC248F71 /* OnboardingData.swift in Sources */,
 				315C4CFA08A29F217F42D2BF /* OnboardingShared.swift in Sources */,
 				230911245A9DCBF6A9C6AEA8 /* OnboardingViewModel.swift in Sources */,
+				39385C5B0814FF112278FF51 /* OnboardingWhatsAppLinkSheet.swift in Sources */,
 				43029DE4468B4C70273E2047 /* OsceModels.swift in Sources */,
 				D60B987372A74F7ABEEF21A1 /* OsceResultView.swift in Sources */,
 				CD764114E07D347F8DF2A44D /* OsceScreen.swift in Sources */,
@@ -1858,9 +1877,8 @@
 				07B30BC927DFC5058114361F /* VitaErrorState.swift in Sources */,
 				1C521DD85F499EB9BF652087 /* VitaFloatingMascot.swift in Sources */,
 				7319EEAD250EC8A9D70605FD /* VitaGlassCard.swift in Sources */,
-				DEC57FCEEC784BFABCDE28D1 /* AgendaScreen.swift in Sources */,
-				EBAD5D7A4F0347FA8240EF9B /* VitaHeroCard.swift in Sources */,
 				D352A531160582F205BF4F47 /* VitaHandle.swift in Sources */,
+				EE4792714534A3C5D8C30E30 /* VitaHeroCard.swift in Sources */,
 				24FA8C62B8B746BE2DF7D459 /* VitaInput.swift in Sources */,
 				EDD8F6E728065C3FF6BDE691 /* VitaMarkdown.swift in Sources */,
 				66989C425ACDD32B3EC1261F /* VitaMascot.swift in Sources */,
@@ -1921,7 +1939,7 @@
 				CODE_SIGN_ENTITLEMENTS = VitaAI/VitaAI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = PJ8972D48J;
 				ENABLE_PREVIEWS = YES;
@@ -1965,7 +1983,7 @@
 				CODE_SIGN_ENTITLEMENTS = VitaAI/VitaAI.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = PJ8972D48J;
 				ENABLE_PREVIEWS = YES;

--- a/VitaAI/Core/Auth/AuthManager.swift
+++ b/VitaAI/Core/Auth/AuthManager.swift
@@ -428,6 +428,8 @@ final class AuthManager: ObservableObject {
             userImage = nil
             isLoggedIn = false
             lastLoginAt = nil
+            // Clear onboarding resume marker so next login starts clean.
+            UserDefaults.standard.removeObject(forKey: "vita_onboarding_last_step")
             SentryConfig.clearUser()
             VitaPostHogConfig.capture(event: "logout")
             VitaPostHogConfig.reset()

--- a/VitaAI/Features/Onboarding/OnboardingConnectSheet.swift
+++ b/VitaAI/Features/Onboarding/OnboardingConnectSheet.swift
@@ -500,14 +500,35 @@ struct PortalWebView: UIViewRepresentable {
             )
             guard isOnPortalDomain else { return }
 
-            // On portal domain: check if we're past the login page
-            let isLoginPage = currentPath.contains("/login") || currentPath.contains("/auth")
-            let isPortalDashboard = !isLoginPage
+            // On portal domain: check if we're past the login page.
+            // Path heuristic catches Canvas/Moodle/SIGAA (distinct /login routes) but
+            // NOT portals like Mannesoft/WebAluno that render the login form inline
+            // on "/webaluno/" itself. So we ALSO probe the DOM for a password input —
+            // if one exists, user hasn't logged in yet and the PHPSESSID we'd capture
+            // is a guest cookie (120 bytes of tracking, not an auth session).
+            let isLoginPath = currentPath.contains("/login") || currentPath.contains("/auth")
+            let isLikelyDashboardByPath = !isLoginPath
 
-            // Capture if: on portal dashboard (login complete) OR 2+ navs on portal domain
-            guard isPortalDashboard || navigationCount >= 3 else { return }
+            // Short-circuit: ≥3 navs on portal domain = trust the state (SSO bounce finished)
+            if navigationCount >= 3 {
+                captureCookiesNow(webView, currentHost: currentHost, currentURL: currentURL)
+                return
+            }
 
-            // Capture ALL cookies from the portal domain — backend decides which ones matter
+            guard isLikelyDashboardByPath else { return }
+
+            // Still ambiguous: probe for a password field. Dashboard pages never have one.
+            webView.evaluateJavaScript("document.querySelector('input[type=\"password\"]') !== null") { [weak self] result, _ in
+                guard let self, !self.capturedSession else { return }
+                if let hasPasswordField = result as? Bool, hasPasswordField {
+                    NSLog("[PortalWebView] %@: login form detected on %@ — waiting for user to authenticate", self.portalType, currentURL)
+                    return
+                }
+                self.captureCookiesNow(webView, currentHost: currentHost, currentURL: currentURL)
+            }
+        }
+
+        private func captureCookiesNow(_ webView: WKWebView, currentHost: String, currentURL: String) {
             webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
                 guard let self, !self.capturedSession else { return }
 
@@ -544,11 +565,20 @@ struct OnboardingPortalFlow: View {
     let portalType: String
     let university: University?
     let api: VitaAPI
+    let userEmail: String?
     let onBack: () -> Void
     let onConnected: () -> Void
 
     @State private var phase: FlowPhase = .login
     @State private var syncVM: PortalConnectViewModel?
+    @State private var extractedPagesCount: Int = 0
+    @State private var extractionSyncMessage: String = "Vita extraindo dados..."
+    // Counters shown on the done screen so the user sees exactly what got imported.
+    @State private var importedGrades: Int = 0
+    @State private var importedSchedule: Int = 0
+    @State private var importedSubjects: Int = 0
+    @State private var importedEvaluations: Int = 0
+    @State private var importedDocuments: Int = 0
 
     private enum FlowPhase {
         case login
@@ -614,11 +644,13 @@ struct OnboardingPortalFlow: View {
                             progress: vm.canvasSyncProgress
                         )
                     } else {
-                        // WebAluno and others use vita-crawl polling
+                        // WebAluno/Mannesoft: surface the real phase + label from /api/portal/sync-progress
+                        // that the bridge pipeline is pushing into the ViewModel. "Login detectado"
+                        // no longer sticks while the LLM is actually extracting grades.
                         ConnectorSyncView(
                             connectorName: portalName,
-                            steps: SyncStep.webalunoSteps(phase: "login"),
-                            message: "Vita extraindo dados..."
+                            steps: SyncStep.webalunoSteps(phase: vm.mannesoftSyncPhase),
+                            message: (vm.mannesoftSyncMessage?.isEmpty == false) ? vm.mannesoftSyncMessage : extractionSyncMessage
                         )
                     }
                 } else {
@@ -638,43 +670,132 @@ struct OnboardingPortalFlow: View {
     // MARK: - Login Phase (WebView)
 
     private var loginPhase: some View {
-        VStack(spacing: 0) {
-            // URL bar
-            HStack(spacing: 8) {
-                Image(systemName: "lock.fill")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.white.opacity(0.3))
-                Text(portalURL.replacingOccurrences(of: "https://", with: "").replacingOccurrences(of: "http://", with: ""))
-                    .font(.system(size: 10))
-                    .foregroundStyle(.white.opacity(0.35))
-                    .lineLimit(1)
-                Spacer()
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color.white.opacity(0.03))
+        Group {
+            if portalType == "webaluno" || portalType == "mannesoft" {
+                // Mannesoft/WebAluno: use the bridge.js-powered flow (same as Settings).
+                // WebAlunoWebViewScreen injects bridge.js, waits for user login, extracts all
+                // required pages, and fires onPagesExtracted with the HTML → /api/portal/extract.
+                WebAlunoWebViewScreen(
+                    onBack: onBack,
+                    onSessionCaptured: { cookie in
+                        handleMannesoftSessionCaptured(cookie)
+                    },
+                    onPagesExtracted: { pages in
+                        handleMannesoftPagesExtracted(pages)
+                    },
+                    userEmail: userEmail,
+                    portalInstanceUrl: portalURL
+                )
+            } else {
+                // Canvas (SSO Google) + other portals: classic PortalWebView with cookie capture.
+                // The DOM password probe added in PortalWebView prevents false positives for portals
+                // that render login inline.
+                VStack(spacing: 0) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.white.opacity(0.3))
+                        Text(portalURL.replacingOccurrences(of: "https://", with: "").replacingOccurrences(of: "http://", with: ""))
+                            .font(.system(size: 10))
+                            .foregroundStyle(.white.opacity(0.35))
+                            .lineLimit(1)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.white.opacity(0.03))
 
-            PortalWebView(
-                portalType: portalType,
-                portalURL: portalURL,
-                onSessionCaptured: { cookie in
-                    handleSessionCaptured(cookie)
+                    PortalWebView(
+                        portalType: portalType,
+                        portalURL: portalURL,
+                        onSessionCaptured: { cookie in
+                            handleSessionCaptured(cookie)
+                        }
+                    )
                 }
-            )
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                )
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
         }
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
-        )
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
+    }
+
+    // MARK: - Mannesoft (bridge.js path)
+
+    /// Cookie captured from Mannesoft after user logs in. Registers the session with backend
+    /// but does NOT mark done — bridge.js will later fire `onPagesExtracted` with the real HTML.
+    private func handleMannesoftSessionCaptured(_ cookie: String) {
+        Task {
+            let instanceUrl = portalURL.hasPrefix("http") ? portalURL : "https://\(portalURL)"
+            // cookie already is "PHPSESSID=..." from bridge-aware WebView, pass as-is
+            _ = try? await api.startVitaCrawl(cookies: cookie, instanceUrl: instanceUrl)
+        }
+    }
+
+    /// Bridge.js finished extracting pages. Send to /api/portal/extract and poll sync-progress.
+    /// Mirrors how Settings → ConnectionsScreen keeps the mannesoftSyncPhase/Message updated
+    /// so the user sees "Buscando notas" etc. instead of a stuck "Login detectado".
+    private func handleMannesoftPagesExtracted(_ pages: [CapturedPortalPage]) {
+        extractedPagesCount = pages.count
+        extractionSyncMessage = "Vita analisando \(pages.count) páginas..."
+        syncVM?.mannesoftSyncPhase = "extracting"
+        syncVM?.mannesoftSyncMessage = "Vita analisando \(pages.count) páginas..."
+        withAnimation { phase = .syncing }
+
+        Task {
+            let apiPages = pages.map {
+                PortalExtractRequestPagesInner(type: $0.type, html: $0.html, linkText: $0.linkText)
+            }
+            let instanceUrl = portalURL.hasPrefix("http") ? portalURL : "https://\(portalURL)"
+            do {
+                let result = try await api.extractPortalPages(
+                    pages: apiPages,
+                    instanceUrl: instanceUrl,
+                    university: university?.name ?? ""
+                )
+                await MainActor.run {
+                    importedGrades = result.grades ?? 0
+                    importedSchedule = result.schedule ?? 0
+                }
+                if let syncId = result.syncId {
+                    for _ in 0..<90 {
+                        try? await Task.sleep(for: .seconds(2))
+                        guard let progress = try? await api.getSyncProgress(syncId: syncId) else { continue }
+                        let label = (progress.label ?? "").isEmpty ? "Vita trabalhando..." : (progress.label ?? "")
+                        await MainActor.run {
+                            syncVM?.mannesoftSyncMessage = label
+                            let lowered = label.lowercased()
+                            if lowered.contains("disciplina") || lowered.contains("matéria") || lowered.contains("materia") {
+                                syncVM?.mannesoftSyncPhase = "disciplines"
+                            } else if lowered.contains("nota") || lowered.contains("grade") {
+                                syncVM?.mannesoftSyncPhase = "grades"
+                            } else if lowered.contains("horário") || lowered.contains("horario") || lowered.contains("schedule") || lowered.contains("aula") {
+                                syncVM?.mannesoftSyncPhase = "schedule"
+                            } else if lowered.contains("extrai") || lowered.contains("extract") || lowered.contains("analisan") || lowered.contains("process") || lowered.contains("parser") || lowered.contains("página") || lowered.contains("pagina") {
+                                syncVM?.mannesoftSyncPhase = "extracting"
+                            }
+                        }
+                        if progress.isDone || progress.isError { break }
+                    }
+                }
+            } catch {
+                NSLog("[OnboardingPortalFlow] extractPortalPages failed: %@", error.localizedDescription)
+            }
+            await MainActor.run {
+                syncVM?.mannesoftSyncPhase = "done"
+                withAnimation { phase = .done }
+            }
+        }
     }
 
     // MARK: - Done Phase
 
     private var donePhase: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: 20) {
             Spacer()
 
             ZStack {
@@ -690,9 +811,32 @@ struct OnboardingPortalFlow: View {
                 .font(.system(size: 20, weight: .bold))
                 .foregroundStyle(.white.opacity(0.9))
 
-            Text("Seus dados foram importados com sucesso.")
-                .font(.system(size: 14))
-                .foregroundStyle(.white.opacity(0.5))
+            let stats = importedStats
+            if stats.isEmpty {
+                Text("Seus dados foram importados com sucesso.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.5))
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(stats, id: \.label) { item in
+                        HStack(spacing: 10) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(VitaColors.dataGreen)
+                                .frame(width: 16)
+                            Text("\(item.count) \(item.label)")
+                                .font(.system(size: 14))
+                                .foregroundStyle(.white.opacity(0.75))
+                            Spacer()
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+                .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.04)))
+                .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.white.opacity(0.06), lineWidth: 1))
+                .padding(.horizontal, 32)
+            }
 
             Button {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -712,6 +856,18 @@ struct OnboardingPortalFlow: View {
         }
     }
 
+    /// Breakdown of what actually got saved, shown on the done screen so the user
+    /// sees "58 notas · 32 horários" instead of a generic success text.
+    private var importedStats: [(count: Int, label: String)] {
+        var items: [(Int, String)] = []
+        if importedSubjects > 0 { items.append((importedSubjects, importedSubjects == 1 ? "matéria" : "matérias")) }
+        if importedGrades > 0 { items.append((importedGrades, importedGrades == 1 ? "nota" : "notas")) }
+        if importedSchedule > 0 { items.append((importedSchedule, importedSchedule == 1 ? "horário" : "horários")) }
+        if importedEvaluations > 0 { items.append((importedEvaluations, importedEvaluations == 1 ? "avaliação" : "avaliações")) }
+        if importedDocuments > 0 { items.append((importedDocuments, importedDocuments == 1 ? "documento" : "documentos")) }
+        return items
+    }
+
     // MARK: - Session Handler
 
     private func handleSessionCaptured(_ cookie: String) {
@@ -723,10 +879,19 @@ struct OnboardingPortalFlow: View {
             let instanceUrl = portalURL.hasPrefix("http") ? portalURL : "https://\(portalURL)"
             vm.connectCanvas(cookies: cookie, instanceUrl: instanceUrl)
 
-            // Watch for completion
+            // Watch for completion, then snapshot the stats from /api/portal/status
+            // so the done screen can show "6 matérias · 10 avaliações · 210 documentos".
             Task {
                 while vm.canvasSyncPhase != .done && vm.canvasSyncPhase != .error {
                     try? await Task.sleep(for: .seconds(0.5))
+                }
+                if let status = try? await api.getCanvasStatus() {
+                    await MainActor.run {
+                        importedSubjects = status.totals?.subjects ?? 0
+                        importedEvaluations = status.totals?.evaluations ?? 0
+                        importedDocuments = status.totals?.documents ?? 0
+                        importedSchedule = status.totals?.schedule ?? 0
+                    }
                 }
                 withAnimation { phase = .done }
             }

--- a/VitaAI/Features/Onboarding/OnboardingShared.swift
+++ b/VitaAI/Features/Onboarding/OnboardingShared.swift
@@ -6,11 +6,12 @@ enum OnboardingStep: Int, CaseIterable {
     case sleep = 0
     case welcome = 1
     case connect = 2
-    case syncing = 3
-    case subjects = 4
-    case notifications = 5
-    case trial = 6
-    case done = 7
+    case extras = 3           // WhatsApp, Google Drive, Calendar, Spotify — tudo opcional
+    case syncing = 4
+    case subjects = 5
+    case notifications = 6
+    case trial = 7
+    case done = 8
 }
 
 // MARK: - Speech Bubble

--- a/VitaAI/Features/Onboarding/OnboardingWhatsAppLinkSheet.swift
+++ b/VitaAI/Features/Onboarding/OnboardingWhatsAppLinkSheet.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// Slim WhatsApp-link flow used by the onboarding `ExtrasStep`. Calls the
+/// same backend contract (`/api/whatsapp/link` + `/api/whatsapp/verify`) as
+/// the Connections screen, but keeps the sheet self-contained so the onboarding
+/// doesn't depend on ConnectorsViewModel.
+struct OnboardingWhatsAppLinkSheet: View {
+    @Binding var phone: String
+    @Binding var code: String
+    @Binding var stepIndex: Int
+    @Binding var sending: Bool
+    @Binding var error: String?
+    let onSendCode: () -> Void
+    let onVerify: () -> Void
+    let onClose: () -> Void
+
+    private var green: Color { Color(red: 0.15, green: 0.68, blue: 0.38) }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Spacer().frame(height: 10)
+                Image(systemName: stepIndex == 2 ? "checkmark.circle.fill" : "message.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(stepIndex == 2 ? .green : green)
+
+                switch stepIndex {
+                case 0: phoneEntry
+                case 1: codeEntry
+                default: connectedState
+                }
+
+                Spacer()
+            }
+            .padding(.top, 20)
+            .background(Color(red: 0.08, green: 0.08, blue: 0.10))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Fechar", action: onClose).foregroundStyle(.gray)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var phoneEntry: some View {
+        Text("Conectar WhatsApp").font(.title2.bold()).foregroundStyle(.white)
+        Text("Receba notificações e converse com a VITA pelo WhatsApp")
+            .font(.subheadline).foregroundStyle(.gray)
+            .multilineTextAlignment(.center).padding(.horizontal)
+        TextField("51989484243", text: $phone)
+            .keyboardType(.phonePad).textContentType(.telephoneNumber)
+            .padding().background(Color.white.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 24).foregroundStyle(.white)
+        if let err = error { Text(err).font(.caption).foregroundStyle(.red) }
+        Button(action: onSendCode) {
+            HStack {
+                if sending { ProgressView().tint(.black) }
+                Text("Enviar código").fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity).padding(.vertical, 14)
+            .background(green).foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(phone.count < 8 || sending).padding(.horizontal, 24)
+    }
+
+    @ViewBuilder private var codeEntry: some View {
+        Text("Digite o código").font(.title2.bold()).foregroundStyle(.white)
+        Text("Enviamos um código de 6 dígitos para seu WhatsApp")
+            .font(.subheadline).foregroundStyle(.gray)
+            .multilineTextAlignment(.center).padding(.horizontal)
+        TextField("000000", text: $code)
+            .keyboardType(.numberPad).textContentType(.oneTimeCode)
+            .multilineTextAlignment(.center)
+            .font(.system(size: 32, weight: .bold, design: .monospaced))
+            .padding().background(Color.white.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 60).foregroundStyle(.white)
+        if let err = error { Text(err).font(.caption).foregroundStyle(.red) }
+        Button(action: onVerify) {
+            HStack {
+                if sending { ProgressView().tint(.black) }
+                Text("Verificar").fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity).padding(.vertical, 14)
+            .background(green).foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .disabled(code.count < 6 || sending).padding(.horizontal, 24)
+        Button("Reenviar código", action: onSendCode)
+            .font(.caption).foregroundStyle(.white.opacity(0.4))
+    }
+
+    @ViewBuilder private var connectedState: some View {
+        Text("WhatsApp conectado!").font(.title2.bold()).foregroundStyle(.white)
+        Text("A VITA vai te mandar uma mensagem de boas-vindas")
+            .font(.subheadline).foregroundStyle(.gray)
+    }
+}

--- a/VitaAI/Features/Onboarding/Steps/ExtrasStep.swift
+++ b/VitaAI/Features/Onboarding/Steps/ExtrasStep.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Onboarding step after the institutional portal: teaches the user that Vita
+/// also works outside the university portal (WhatsApp, Drive, Calendar, Spotify).
+///
+/// All connections are optional — user can hit "Pular" at the bottom button row.
+/// WhatsApp is the headline because it's already live end-to-end.
+/// The other cards open the existing `/integrations/<provider>` OAuth flow.
+struct ExtrasStep: View {
+    let api: VitaAPI
+    let onConnectWhatsApp: () -> Void
+    let onConnectIntegration: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            OnboardingSpeechBubble(
+                text: "A VITA também vive fora da faculdade. Conecta o que fizer sentido — tudo opcional."
+            )
+
+            VStack(spacing: 10) {
+                extraCard(
+                    letter: "W",
+                    name: "WhatsApp",
+                    subtitle: "Receba lembretes e fale com a VITA pelo zap",
+                    color: Color(red: 0.15, green: 0.68, blue: 0.38),
+                    badge: "DESTAQUE",
+                    action: onConnectWhatsApp
+                )
+                extraCard(
+                    letter: "D",
+                    name: "Google Drive",
+                    subtitle: "Vita lê e organiza seus PDFs do Drive",
+                    color: Color(red: 0.25, green: 0.52, blue: 0.96),
+                    badge: nil,
+                    action: { onConnectIntegration("google_drive") }
+                )
+                extraCard(
+                    letter: "C",
+                    name: "Google Calendar",
+                    subtitle: "Sincroniza provas, trabalhos e aulas",
+                    color: Color(red: 0.96, green: 0.55, blue: 0.25),
+                    badge: nil,
+                    action: { onConnectIntegration("google_calendar") }
+                )
+                extraCard(
+                    letter: "♫",
+                    name: "Spotify",
+                    subtitle: "Música de foco durante a transcrição",
+                    color: Color(red: 0.11, green: 0.73, blue: 0.33),
+                    badge: nil,
+                    action: { onConnectIntegration("spotify") }
+                )
+            }
+        }
+        .padding(.horizontal, 20)
+    }
+
+    @ViewBuilder
+    private func extraCard(
+        letter: String,
+        name: String,
+        subtitle: String,
+        color: Color,
+        badge: String?,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(color.opacity(0.18))
+                        .frame(width: 44, height: 44)
+                    Text(letter)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(color)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(name)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.95))
+                        if let badge {
+                            Text(badge)
+                                .font(.system(size: 8, weight: .bold))
+                                .foregroundStyle(VitaColors.accent)
+                                .padding(.horizontal, 6).padding(.vertical, 2)
+                                .background(Capsule().fill(VitaColors.accent.opacity(0.14)))
+                        }
+                    }
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.55))
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.30))
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.white.opacity(0.04))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/VitaAI/Features/Onboarding/VitaOnboarding.swift
+++ b/VitaAI/Features/Onboarding/VitaOnboarding.swift
@@ -27,6 +27,13 @@ struct VitaOnboarding: View {
     @State private var mascotScale: CGFloat = 1.0
     @State private var showManualEntry = false
     @State private var typeTextId: UUID = UUID()
+    // WhatsApp quick-link sheet, used by the ExtrasStep.
+    @State private var showExtrasWAsheet = false
+    @State private var waPhone = ""
+    @State private var waCode = ""
+    @State private var waStep = 0
+    @State private var waSending = false
+    @State private var waError: String?
     var userName: String = ""
     var onLogout: (() -> Void)?
     var onComplete: () -> Void
@@ -177,6 +184,20 @@ struct VitaOnboarding: View {
                 }
             }
         }
+        .sheet(isPresented: $showExtrasWAsheet) {
+            OnboardingWhatsAppLinkSheet(
+                phone: $waPhone,
+                code: $waCode,
+                stepIndex: $waStep,
+                sending: $waSending,
+                error: $waError,
+                onSendCode: sendWACode,
+                onVerify: verifyWACode,
+                onClose: { showExtrasWAsheet = false }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
         .onAppear {
             if viewModel == nil {
                 viewModel = OnboardingViewModel(tokenStore: container.tokenStore, api: container.api)
@@ -232,6 +253,24 @@ struct VitaOnboarding: View {
                 }
             }
 
+        case .extras:
+            ExtrasStep(
+                api: container.api,
+                onConnectWhatsApp: {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    waStep = 0; waPhone = ""; waCode = ""; waError = nil
+                    showExtrasWAsheet = true
+                },
+                onConnectIntegration: { provider in
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    Task {
+                        // Kicks off OAuth; ConnectorsScreen will show the
+                        // result when the user lands on it post-onboarding.
+                        _ = try? await container.api.startIntegrationOAuth(provider)
+                    }
+                }
+            )
+
         case .syncing:
             if let vm = viewModel {
                 SyncingStep(api: container.api, viewModel: vm)
@@ -286,7 +325,7 @@ struct VitaOnboarding: View {
             .disabled(step == .welcome && viewModel?.selectedUniversity == nil)
             .opacity(step == .welcome && viewModel?.selectedUniversity == nil ? 0.3 : 1)
 
-            if step == .welcome || step == .connect || step == .subjects {
+            if step == .welcome || step == .connect || step == .extras || step == .subjects {
                 Button(action: {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     nextStep()
@@ -307,6 +346,7 @@ struct VitaOnboarding: View {
         case .sleep: return ""
         case .welcome: return String(localized: "onboarding_btn_continue")
         case .connect: return String(localized: "onboarding_btn_continue")
+        case .extras: return String(localized: "onboarding_btn_continue")
         case .syncing: return String(localized: "onboarding_btn_continue")
         case .subjects: return String(localized: "onboarding_btn_continue")
         case .notifications: return String(localized: "onboarding_btn_notifications")
@@ -519,6 +559,34 @@ struct VitaOnboarding: View {
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
+            }
+        }
+    }
+
+    // MARK: - WhatsApp sheet actions (used by ExtrasStep)
+
+    private func sendWACode() {
+        Task {
+            await MainActor.run { waSending = true; waError = nil }
+            do {
+                try await container.api.linkWhatsApp(phone: waPhone)
+                await MainActor.run { waStep = 1; waSending = false }
+            } catch {
+                await MainActor.run { waError = "Erro ao enviar código"; waSending = false }
+            }
+        }
+    }
+
+    private func verifyWACode() {
+        Task {
+            await MainActor.run { waSending = true; waError = nil }
+            do {
+                _ = try await container.api.verifyWhatsApp(code: waCode)
+                await MainActor.run { waStep = 2; waSending = false }
+                try? await Task.sleep(for: .seconds(2))
+                await MainActor.run { showExtrasWAsheet = false }
+            } catch {
+                await MainActor.run { waError = "Código inválido ou expirado"; waSending = false }
             }
         }
     }

--- a/VitaAI/Features/Onboarding/VitaOnboarding.swift
+++ b/VitaAI/Features/Onboarding/VitaOnboarding.swift
@@ -11,6 +11,9 @@ private struct PortalSheetItem: Identifiable {
 
 struct VitaOnboarding: View {
     @Environment(\.appContainer) private var container
+    // Persist current step so if the app restarts mid-onboarding the user
+    // resumes where they stopped instead of going back to the sleep intro.
+    @AppStorage("vita_onboarding_last_step") private var lastStepRaw: Int = OnboardingStep.sleep.rawValue
     @State private var step: OnboardingStep = .sleep
     @State private var mascotState: MascotState = .sleeping
     @State private var viewModel: OnboardingViewModel?
@@ -98,18 +101,34 @@ struct VitaOnboarding: View {
                     .transition(.opacity)
                 }
 
-                // Mascot (tap to wake on sleep step, hidden during inline portal connect)
+                // Mascot (tap to wake on sleep step, hidden during inline portal connect,
+                // shrinks while user is actively searching a university so the dropdown
+                // has room to show multiple results without the keyboard clipping it).
+                let shrinkForSearch = step == .welcome
+                    && !(viewModel?.universityQuery.isEmpty ?? true)
+                    && viewModel?.selectedUniversity == nil
                 if !(step == .connect && inlineConnectPortal != nil) {
-                    VitaMascot(state: mascotState, size: step == .sleep ? 120 : 100)
+                    VitaMascot(
+                        state: mascotState,
+                        size: step == .sleep ? 120 : (shrinkForSearch ? 44 : 100)
+                    )
                         .scaleEffect(mascotScale)
-                        .padding(.top, step == .sleep ? 60 : 16)
-                        .padding(.bottom, step == .sleep ? 0 : 8)
+                        .padding(.top, step == .sleep ? 60 : (shrinkForSearch ? 0 : 16))
+                        .padding(.bottom, step == .sleep ? 0 : (shrinkForSearch ? 0 : 8))
+                        .overlay(alignment: .top) {
+                            if step == .sleep && mascotState == .sleeping {
+                                SleepingZs()
+                                    .offset(x: 34, y: 6)
+                                    .allowsHitTesting(false)
+                            }
+                        }
                         .onTapGesture {
                             if step == .sleep {
                                 UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                                 wakeUp()
                             }
                         }
+                        .animation(.easeInOut(duration: 0.25), value: shrinkForSearch)
                 }
 
                 // Speech bubble + content
@@ -163,6 +182,19 @@ struct VitaOnboarding: View {
                 viewModel = OnboardingViewModel(tokenStore: container.tokenStore, api: container.api)
                 Task { await viewModel?.loadUniversities() }
             }
+            // Resume from the last step the user reached (unless they'd fully completed it —
+            // .done means the flow is over and we'd never be shown anyway).
+            if let saved = OnboardingStep(rawValue: lastStepRaw),
+               saved != .sleep,
+               saved != .done {
+                step = saved
+                mascotState = .awake
+                showContent = true
+            }
+        }
+        .onChange(of: step) { newStep in
+            // Persist every transition so a mid-flow restart resumes exactly here.
+            lastStepRaw = newStep.rawValue
         }
     }
 
@@ -185,6 +217,7 @@ struct VitaOnboarding: View {
                     portalType: activePortal,
                     university: viewModel?.selectedUniversity,
                     api: container.api,
+                    userEmail: container.authManager.userEmail,
                     onBack: { withAnimation { inlineConnectPortal = nil } },
                     onConnected: {
                         withAnimation { inlineConnectPortal = nil }
@@ -475,6 +508,9 @@ struct VitaOnboarding: View {
         guard let vm = viewModel else { return }
         await vm.complete()
         AppConfig.setOnboardingComplete(true)
+        // Onboarding finished — clear the resume marker so a future fresh login
+        // (or an account reset) starts from .sleep again.
+        lastStepRaw = OnboardingStep.sleep.rawValue
     }
 
     private func requestNotificationPermission() {
@@ -485,5 +521,36 @@ struct VitaOnboarding: View {
                 }
             }
         }
+    }
+}
+
+// Cascade of 3 Z's drifting up+fading right above the mascot's head —
+// classic sleeping cartoon vibe. Only shown while it's actually asleep.
+private struct SleepingZs: View {
+    @State private var animate = false
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            zLetter(size: 12, delay: 0.0)
+            zLetter(size: 16, delay: 0.6).offset(x: 9)
+            zLetter(size: 20, delay: 1.2).offset(x: 20)
+        }
+        .frame(width: 52, height: 36, alignment: .bottomLeading)
+        .onAppear { animate = true }
+    }
+
+    @ViewBuilder
+    private func zLetter(size: CGFloat, delay: Double) -> some View {
+        Text("Z")
+            .font(.system(size: size, weight: .heavy, design: .rounded))
+            .foregroundStyle(Color.white.opacity(0.55))
+            .offset(y: animate ? -26 : 0)
+            .opacity(animate ? 0 : 1)
+            .animation(
+                .easeOut(duration: 1.8)
+                    .repeatForever(autoreverses: false)
+                    .delay(delay),
+                value: animate
+            )
     }
 }

--- a/VitaAI/Info.plist
+++ b/VitaAI/Info.plist
@@ -28,24 +28,18 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>84</string>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-	<key>NSCameraUsageDescription</key>
-	<string>VitaAI usa a camera quando voce escolhe tirar foto de uma questao ou anotacao para enviar no chat Vita.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>VitaAI usa dados de sono e exercicio para correlacionar com seu desempenho academico.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>VitaAI pode registrar sessoes de estudo como atividade mindfulness na Saude, so com sua permissao.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>VitaAI precisa do microfone para gravar suas aulas e gerar transcricoes automaticas.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>VitaAI acessa sua galeria quando voce escolhe anexar uma imagem no chat Vita.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>VitaAI usa reconhecimento de fala para transcrever suas aulas em tempo real.</string>
 	<key>SENTRY_DSN</key>


### PR DESCRIPTION
## Summary

Nova etapa no onboarding (entre conector institucional e syncing) apresentando os conectores opcionais. WhatsApp em destaque porque o E2E backend acabou de entrar em [vitaai-web#145](https://github.com/by-mav/vitaai-web/pull/145).

**Fluxo resultante**: `sleep → welcome → connect (portal institucional) → extras (WhatsApp/Drive/Calendar/Spotify) → syncing → subjects → notifications → trial → done`.

## Files

- \`OnboardingShared.swift\` — novo case \`.extras = 3\`, steps seguintes renumeradas (\`syncing=4..done=8\`).
- \`Steps/ExtrasStep.swift\` (novo) — 4 cards clicáveis.
- \`OnboardingWhatsAppLinkSheet.swift\` (novo) — sheet 2-step (telefone → código → confirmado) consumindo \`/api/whatsapp/link\` + \`/api/whatsapp/verify\`.
- \`VitaOnboarding.swift\` — wire do novo step (switch case, buttonText, skip button, sheet, handlers \`sendWACode\`/\`verifyWACode\`).

## Backend contract

Depende do [vitaai-web PR #145](https://github.com/by-mav/vitaai-web/pull/145) (já validado live em dev).

- \`GET  /api/whatsapp/status\`
- \`POST /api/whatsapp/link {phone}\`
- \`POST /api/whatsapp/verify {code}\` → \`{ok, verified}\`
- \`POST /api/whatsapp/unlink\`

## Test plan

- [x] \`./scripts/dev-sim.sh\` — \`** BUILD SUCCEEDED **\` no iPhone 17 Pro
- [x] Pre-commit hook (xcodebuild + subject check) passed
- [ ] Rafael navega pelo onboarding real pra ver o card rendering + tap → sheet (login OAuth necessário, não automatizável no sim)

## Follow-ups

- Android paridade (droid agent)
- Analytics events no tap de cada card