### PR TITLE
fix(onboarding): align with openapi.yaml, never declare completion client-side

### DIFF
--- a/VitaAI/Core/Network/VitaAPI.swift
+++ b/VitaAI/Core/Network/VitaAPI.swift
@@ -422,7 +422,14 @@ actor VitaAPI {
     // MARK: - Onboarding
 
     func postOnboarding(_ body: OnboardingPostRequest) async throws {
-        let _: EmptyResponse = try await client.post("onboarding", body: body)
+        // Use postRaw with camelCase encoder — backend Zod schema expects camelCase
+        // (studyGoal, selectedSubjects...), but default HTTPClient encoder applies
+        // .convertToSnakeCase which turns `studyGoal` into `study_goal` and triggers
+        // reject_validation on the server. Incident: 2026-04-22 onboarding loop.
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .useDefaultKeys
+        let data = try encoder.encode(body)
+        let _: EmptyResponse = try await client.postRaw("onboarding", body: data)
     }
 
     func requestUniversity(name: String, city: String, state: String) async throws {
@@ -727,6 +734,13 @@ actor VitaAPI {
         try await client.get("integrations")
     }
 
+    /// Unified list matching current backend shape `{providers: [...]}`.
+    /// IntegrationsStore reads from here; the older `getIntegrations()` above
+    /// is kept only for the academic/productivity split in ConnectorsViewModel.
+    func listIntegrationProviders() async throws -> IntegrationProvidersListResponse {
+        try await client.get("integrations")
+    }
+
     func startIntegrationOAuth(_ provider: String) async throws -> IntegrationOAuthResponse {
         try await client.get("integrations/\(provider)")
     }
@@ -771,12 +785,21 @@ actor VitaAPI {
 
 // MARK: - Request Types
 
+// Matches openapi.yaml /api/onboarding request body (required: moment, studyGoal).
+// CLAUDE.md iOS: "NUNCA criar models manuais para endpoints que existem no openapi.yaml"
+// — temporário até o codegen cobrir request bodies. Don't add fields without
+// also updating openapi.yaml and backend onboardingSchema (src/lib/validators.ts).
 struct OnboardingPostRequest: Encodable {
     let moment: String
     let studyGoal: String
     var year: Int?
+    var semester: Int?
+    var highSchoolYear: Int?
+    var examBoard: String?
     var selectedSubjects: [String]?
     var subjectDifficulties: [String: String]?
+    var university: String?
+    var universityLms: String?
 }
 
 struct UniversityRequestBody: Encodable {

--- a/VitaAI/Features/Onboarding/OnboardingViewModel.swift
+++ b/VitaAI/Features/Onboarding/OnboardingViewModel.swift
@@ -9,6 +9,7 @@ final class OnboardingViewModel {
 
     // MARK: - Navigation
     var isSaving = false
+    var completionError: String?
 
     // MARK: - Welcome
     var nickname: String = ""
@@ -152,8 +153,15 @@ final class OnboardingViewModel {
 
     // MARK: - Save
 
-    func complete() async {
+    /// Submits onboarding to backend FIRST. Only on 200 do we persist local state
+    /// and emit the analytics event. If backend rejects, throws — the view stays on
+    /// the onboarding screen so the user can retry. Never declare completion client-side
+    /// ahead of server-acknowledged persistence (incident 2026-04-22 onboarding loop).
+    func complete() async throws {
         isSaving = true
+        completionError = nil
+        defer { isSaving = false }
+
         let subjects = syncedSubjects.map(\.name)
         let data = OnboardingData(
             nickname: nickname.trimmingCharacters(in: .whitespaces),
@@ -163,39 +171,60 @@ final class OnboardingViewModel {
             subjects: subjects,
             subjectDifficulties: subjectDifficulties
         )
+
+        try await postOnboardingToBackend(data: data)
+
+        // Backend acknowledged — safe to commit local + analytics.
+        await tokenStore.saveOnboardingData(data)
         VitaPostHogConfig.capture(event: "onboarding_completed", properties: [
             "university_name": data.universityName,
             "semester": data.semester,
             "disciplines_count": subjects.count,
             "portal_connected": !syncedSubjects.isEmpty,
         ])
-        await tokenStore.saveOnboardingData(data)
-        await postOnboardingToBackend(data: data)
-        isSaving = false
     }
 
     // MARK: - Backend Sync
 
-    private func postOnboardingToBackend(data: OnboardingData) async {
+    private func postOnboardingToBackend(data: OnboardingData) async throws {
         guard let api else {
-            print("[OnboardingVM] No API available to post onboarding data")
-            return
+            throw OnboardingCompletionError.apiUnavailable
         }
+
+        let lms = selectedUniversity?.primaryPortal?.portalType
+        let universityName: String? = {
+            let name = data.universityName.trimmingCharacters(in: .whitespaces)
+            return name.isEmpty ? nil : name
+        }()
 
         let body = OnboardingPostRequest(
             moment: "graduacao",
             studyGoal: "graduacao",
             year: data.semester > 0 ? data.semester : nil,
+            semester: data.semester > 0 ? data.semester : nil,
+            highSchoolYear: nil,
+            examBoard: nil,
             selectedSubjects: data.subjects.isEmpty ? nil : data.subjects,
-            subjectDifficulties: data.subjectDifficulties.isEmpty ? nil : data.subjectDifficulties
+            subjectDifficulties: data.subjectDifficulties.isEmpty ? nil : data.subjectDifficulties,
+            university: universityName,
+            universityLms: lms
         )
 
-        do {
-            try await api.postOnboarding(body)
-        } catch {
-            // HTTPClient already retries 3x with exponential backoff for 5xx/network errors
-            // and handles 401 with token refresh. If we still fail, log it.
-            print("[OnboardingVM] Failed to post onboarding data: \(error.localizedDescription)")
+        // HTTPClient already retries 3x with exponential backoff for 5xx/network
+        // errors and handles 401 with token refresh. Any error here means the
+        // backend actually rejected (e.g. validation) — propagate so the caller
+        // leaves the user on the onboarding screen instead of marking complete.
+        try await api.postOnboarding(body)
+    }
+}
+
+enum OnboardingCompletionError: LocalizedError {
+    case apiUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .apiUnavailable:
+            return "Não foi possível contatar o servidor. Tente novamente."
         }
     }
 }

--- a/VitaAI/Features/Onboarding/VitaOnboarding.swift
+++ b/VitaAI/Features/Onboarding/VitaOnboarding.swift
@@ -264,9 +264,14 @@ struct VitaOnboarding: View {
                 onConnectIntegration: { provider in
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     Task {
-                        // Kicks off OAuth; ConnectorsScreen will show the
-                        // result when the user lands on it post-onboarding.
-                        _ = try? await container.api.startIntegrationOAuth(provider)
+                        do {
+                            let data = try await container.api.startIntegrationOAuth(provider)
+                            if let urlStr = data.authUrl, let url = URL(string: urlStr) {
+                                await MainActor.run { UIApplication.shared.open(url) }
+                            }
+                        } catch {
+                            NSLog("[Onboarding] startIntegrationOAuth(%@) failed: %@", provider, error.localizedDescription)
+                        }
                     }
                 }
             )
@@ -546,11 +551,18 @@ struct VitaOnboarding: View {
 
     private func saveOnboarding() async {
         guard let vm = viewModel else { return }
-        await vm.complete()
-        AppConfig.setOnboardingComplete(true)
-        // Onboarding finished — clear the resume marker so a future fresh login
-        // (or an account reset) starts from .sleep again.
-        lastStepRaw = OnboardingStep.sleep.rawValue
+        do {
+            try await vm.complete()
+            AppConfig.setOnboardingComplete(true)
+            // Onboarding finished — clear the resume marker so a future fresh login
+            // (or an account reset) starts from .sleep again.
+            lastStepRaw = OnboardingStep.sleep.rawValue
+        } catch {
+            // Backend rejected or unreachable — surface the error in the VM and
+            // stay on the screen. Never persist local "completed" flag ahead of
+            // server ack (incident 2026-04-22 onboarding loop).
+            vm.completionError = error.localizedDescription
+        }
     }
 
     private func requestNotificationPermission() {


### PR DESCRIPTION
## Problem

3 compounded bugs trapped authenticated users in an onboarding loop on every login (family: incidents 2026-04-12 auth-profile-404, 2026-04-19 logout-regression, and today 2026-04-22).

**1. Manual struct missing fields that openapi.yaml declares.**
`OnboardingPostRequest` in `VitaAPI.swift:781` was hand-written and omitted `university`, `universityLms`, `semester`, `highSchoolYear`, `examBoard`. Only `moment/studyGoal/year/selectedSubjects/subjectDifficulties` were sent. Consequence: user picks faculty in UI → `user_profiles.university` saved as empty string. Violates CLAUDE.md iOS rule *"NUNCA criar models manuais para endpoints que existem no openapi.yaml"*.

**2. Snake-case encoder mangles camelCase contract.**
`postOnboarding` used `client.post` which applies `.convertToSnakeCase` (HTTPClient.swift:103-104). Swift `studyGoal` → JSON `study_goal`, but the Zod schema on the server expects camelCase. Every submission returned `reject_validation(["studyGoal"])` in backend logs. Fix: use `postRaw` with `.useDefaultKeys` encoder, same pattern as `ingestCanvasData` already does.

**3. Client declared victory before server ack.**
`OnboardingViewModel.complete()` captured the `onboarding_completed` PostHog event and called `tokenStore.saveOnboardingData(data)` BEFORE the POST; the inner `try await api.postOnboarding(body)` had a catch that just `print()`'d the error. So even when backend 400'd, the client persisted the local "completed" flag, navigated to dashboard, and on next login/profile-refresh the backend still had `onboardingCompleted=false` → AppRouter gate sent user back to onboarding.

Fix: `complete()` is now `async throws`. Backend call happens first; local save + analytics only run on success. `VitaOnboarding.saveOnboarding()` wraps it in try/catch and surfaces `completionError` on the view model instead of advancing `AppConfig.setOnboardingComplete(true)`. Never mark completed client-side ahead of server ack.

## Verification

- `./scripts/dev-sim.sh` (iPhone 17 Pro) — build green, app installed fresh
- Pre-commit build hook passed
- Backend log pattern will change from `reject_validation(["studyGoal"])` to either 201 + persisted `university`, or 4xx that leaves user on the onboarding screen (observable via `completionError`)

## Related

- Backend self-healing normalize: [vitaai-web#146](https://github.com/by-mav/vitaai-web/pull/146) — `/api/portal/ingest` now auto-calls `normalizePortalData` so `academic_subjects` fills without waiting for the cron.
- Incidents: `agent-brain/incidents/vitaai/2026-04-12_auth-profile-404-onboarding-loop.md`, `2026-04-19_logout-to-onboarding-regression.md`, and a new one I'll open for 2026-04-22 covering this round + the arch-drift root cause.

## Known out of scope (separate PR)

- `OnboardingPostRequest` should be generated from `openapi.yaml` request bodies (current codegen only emits responses). Manual struct is the temporary bridge; follow-up is extending `sync-api-spec.sh` to cover request bodies.
- Haiku extractor not yet emitting the 12 canonical domains per `vita-extractor-canonical-list.md` (missing `semester` on history rows, no `kind:partial` records for AP1). That's why `user_profiles.semester=1` even when user has multi-year history.