### PR TITLE
feat(transcricao): Vita mascote + R2 upload + gold-standard recorder UX

### DIFF
--- a/VitaAI.xcodeproj/project.pbxproj
+++ b/VitaAI.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		C52494A58E7D648228BB0136 /* QBankShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18071D7DB89A34DE11E9EE5E /* QBankShared.swift */; };
 		C69655D848D9D73894AB57E5 /* RatingButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443BC23869204129FA12AD43 /* RatingButtons.swift */; };
 		C7D54158E4BD8D03FC9E5CAB /* TranscricaoRecorderContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06A39AB6561313018C22261 /* TranscricaoRecorderContent.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* TranscricaoControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A3 /* TranscricaoControls.swift */; };
 		C953601D99886606AE8D3BBE /* VitaColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3CAA9D7ADA613A3FDC5EBD /* VitaColors.swift */; };
 		C9A5EB24F32CC606981DBF10 /* StudyOverviewTranscricoes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3277C8F9B81F4549160015AA /* StudyOverviewTranscricoes.swift */; };
 		CA1746035639EFED3B1F97E2 /* ConnectorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2373B8651D45CEF182E7E602 /* ConnectorCard.swift */; };
@@ -580,6 +581,7 @@
 		BFD6AFE54F4B84099E4031E3 /* MindMapStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindMapStore.swift; sourceTree = "<group>"; };
 		C0387CC7FD36268CA8C03B06 /* OsceSseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OsceSseClient.swift; sourceTree = "<group>"; };
 		C06A39AB6561313018C22261 /* TranscricaoRecorderContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscricaoRecorderContent.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6A7B8C9D0E1F2A3 /* TranscricaoControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscricaoControls.swift; sourceTree = "<group>"; };
 		C0ACCC75B6BF005D29AF766F /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 		C0FA504A01F65E8D393C782C /* TrabalhoDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrabalhoDetailScreen.swift; sourceTree = "<group>"; };
 		C1ACF21598F20E4035C39378 /* SyncProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProgress.swift; sourceTree = "<group>"; };
@@ -1133,6 +1135,7 @@
 				6FAA707AA80C46FF82D6CF91 /* VitaTypingMascot.swift */,
 				195A69CD6776A957B920D6E0 /* TranscricaoProfessorSignals.swift */,
 				C06A39AB6561313018C22261 /* TranscricaoRecorderContent.swift */,
+				B2C3D4E5F6A7B8C9D0E1F2A3 /* TranscricaoControls.swift */,
 				87EA1E56084FA3D11CAD0F7E /* TranscricaoScreen.swift */,
 				7BD3F3D91DE3FE5D24710650 /* TranscricaoShared.swift */,
 				44EAF7F741D5CD9DCC447A01 /* TranscricaoViewModel.swift */,
@@ -1861,6 +1864,7 @@
 				4D8E29251018433D88921241 /* VitaTypingMascot.swift in Sources */,
 				ED940D904DE51599BECDDBF3 /* TranscricaoProfessorSignals.swift in Sources */,
 				C7D54158E4BD8D03FC9E5CAB /* TranscricaoRecorderContent.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* TranscricaoControls.swift in Sources */,
 				9498CF9FCCC1FF64AD017D5A /* TranscricaoScreen.swift in Sources */,
 				269EC1EAF179BEE70B65C0FC /* TranscricaoShared.swift in Sources */,
 				80FFA5B7EFB7E479E6E33150 /* TranscricaoViewModel.swift in Sources */,

--- a/VitaAI/Core/Network/TranscricaoClient.swift
+++ b/VitaAI/Core/Network/TranscricaoClient.swift
@@ -257,10 +257,24 @@ actor TranscricaoClient {
         self.onUnauthorized = handler
     }
 
-    // MARK: - Upload + Stream
+    // MARK: - Upload + Stream (R2 direct upload)
 
-    /// Uploads audio file and returns an SSE stream with progress/completion events.
-    func uploadAndStream(fileURL: URL) -> AsyncThrowingStream<TranscricaoSSEEvent, Error> {
+    /// Uploads audio via 3-step R2 flow + returns an SSE stream with progress
+    /// and completion events.
+    ///
+    /// Flow (gold-standard, avoids buffering the file on the app server):
+    ///   1. `POST /api/audio/upload-url` → `{r2Key, sourceId, presignedPutUrl}`
+    ///   2. `PUT  <presignedPutUrl>` with the m4a body — goes direct to CF edge
+    ///   3. `POST /api/ai/transcribe` with JSON `{r2Key, sourceId, language, discipline}`
+    ///      returns SSE progress → transcript → summary → flashcards
+    ///
+    /// If step 1 or 2 fails, falls back to the legacy multipart POST so older
+    /// backends (and non-R2 dev envs) keep working.
+    func uploadAndStream(
+        fileURL: URL,
+        language: String = "pt",
+        discipline: String? = nil
+    ) -> AsyncThrowingStream<TranscricaoSSEEvent, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 do {
@@ -268,111 +282,270 @@ actor TranscricaoClient {
                         continuation.finish(throwing: APIError.noData)
                         return
                     }
+                    let fileName = fileURL.lastPathComponent
 
-                    let boundary = "VitaBoundary-\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
-                    var body = Data()
-                    body.append(formPart(boundary: boundary, name: "audio", filename: "audio.m4a",
-                                         contentType: "audio/m4a", data: fileData))
-                    body.append("--\(boundary)--\r\n".utf8Data)
-
-                    guard let url = URL(string: AppConfig.apiBaseURL + "/ai/transcribe") else {
-                        continuation.finish(throwing: APIError.invalidURL)
-                        return
-                    }
-
-                    var didAttemptRefresh = false
-                    var lastError: Error = APIError.unknown
-
-                    for attempt in 0..<Self.maxRetries {
-                        if attempt > 0 {
-                            let delay = UInt64(pow(2.0, Double(attempt - 1)) * 1_000_000_000)
-                            try await Task.sleep(nanoseconds: delay)
-                        }
-
-                        var request = URLRequest(url: url)
-                        request.httpMethod = "POST"
-                        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-                        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-                        request.httpBody = body
-                        request.timeoutInterval = 180
-
-                        if let token = await self.tokenStore.token {
-                            request.setValue("__Secure-better-auth.session_token=\(token)", forHTTPHeaderField: "Cookie")
-                        }
-
-                        let bytes: URLSession.AsyncBytes
-                        let response: URLResponse
+                    // Try R2 flow first
+                    if let uploadInfo = try? await self.requestUploadUrl(
+                        fileName: fileName,
+                        discipline: discipline,
+                        language: language,
+                        fileSize: fileData.count
+                    ) {
                         do {
-                            (bytes, response) = try await self.session.bytes(for: request)
+                            try await self.putToR2(presignedUrl: uploadInfo.presignedPutUrl, data: fileData)
+                            continuation.yield(.progress(stage: "Preparando transcrição...", percent: 5))
+                            try await self.streamTranscribeJson(
+                                r2Key: uploadInfo.r2Key,
+                                sourceId: uploadInfo.sourceId,
+                                language: language,
+                                discipline: discipline,
+                                continuation: continuation
+                            )
+                            return
                         } catch {
-                            lastError = APIError.networkError(error)
-                            continue
+                            // R2 PUT or transcribe call failed — fall through to multipart fallback
+                            NSLog("[TranscricaoClient] R2 flow failed, falling back to multipart: %@", "\(error)")
                         }
-
-                        guard let httpResponse = response as? HTTPURLResponse else {
-                            lastError = APIError.unknown
-                            continue
-                        }
-
-                        if httpResponse.statusCode == 401 {
-                            if !didAttemptRefresh {
-                                didAttemptRefresh = true
-                                if await self.tokenRefresher.refreshSession() {
-                                    continue
-                                }
-                            }
-                            if let handler = self.onUnauthorized { await handler() }
-                            continuation.finish(throwing: APIError.unauthorized)
-                            return
-                        }
-
-                        guard (200...299).contains(httpResponse.statusCode) else {
-                            if (500...599).contains(httpResponse.statusCode) {
-                                lastError = APIError.serverError(httpResponse.statusCode)
-                                continue
-                            }
-                            continuation.finish(throwing: APIError.serverError(httpResponse.statusCode))
-                            return
-                        }
-
-                        // Connected — stream events (no retry mid-stream)
-                        var eventType = ""
-                        var dataLines: [String] = []
-
-                        for try await line in bytes.lines {
-                            if line.hasPrefix("event:") {
-                                eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
-                            } else if line.hasPrefix("data:") {
-                                let content = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
-                                dataLines.append(content)
-                            } else if line.isEmpty, !dataLines.isEmpty {
-                                let rawJSON = dataLines.joined(separator: "\n")
-                                dataLines = []
-                                if let event = Self.parse(type: eventType, data: rawJSON) {
-                                    continuation.yield(event)
-                                    switch event {
-                                    case .complete, .error:
-                                        continuation.finish()
-                                        return
-                                    default:
-                                        break
-                                    }
-                                }
-                                eventType = ""
-                            }
-                        }
-
-                        continuation.finish()
-                        return
                     }
 
-                    // All retries exhausted
-                    continuation.finish(throwing: lastError)
+                    // Legacy multipart fallback (older backend, R2 not configured, etc.)
+                    try await self.streamTranscribeMultipart(
+                        fileData: fileData,
+                        language: language,
+                        discipline: discipline,
+                        continuation: continuation
+                    )
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
         }
+    }
+
+    // MARK: - R2 flow helpers
+
+    private struct AudioUploadInfo: Decodable {
+        let sourceId: String
+        let r2Key: String
+        let presignedPutUrl: String
+        let expiresAt: String
+    }
+
+    /// Step 1: ask the server for a pre-signed PUT URL.
+    private func requestUploadUrl(
+        fileName: String,
+        discipline: String?,
+        language: String,
+        fileSize: Int
+    ) async throws -> AudioUploadInfo {
+        guard let url = URL(string: AppConfig.apiBaseURL + "/audio/upload-url") else {
+            throw APIError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = await self.tokenStore.token {
+            request.setValue("__Secure-better-auth.session_token=\(token)", forHTTPHeaderField: "Cookie")
+        }
+        var body: [String: Any] = [
+            "fileName": fileName,
+            "language": language,
+            "contentType": "audio/m4a",
+            "durationSeconds": 0,
+        ]
+        if let discipline = discipline, !discipline.isEmpty, discipline != "Auto-detectar" {
+            body["discipline"] = discipline
+        }
+        body["fileSize"] = fileSize
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
+
+        let (data, response) = try await self.session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw APIError.serverError(code)
+        }
+        return try JSONDecoder().decode(AudioUploadInfo.self, from: data)
+    }
+
+    /// Step 2: PUT the m4a bytes straight to R2. Uses the plain URLSession
+    /// (not the auth'd session) because the presigned URL carries the auth
+    /// in its query string and CF would reject extra headers.
+    private func putToR2(presignedUrl: String, data: Data) async throws {
+        guard let url = URL(string: presignedUrl) else { throw APIError.invalidURL }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("audio/m4a", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 300
+        let putSession = URLSession(configuration: .default)
+        let (_, response) = try await putSession.upload(for: request, from: data)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw APIError.serverError(code)
+        }
+    }
+
+    /// Step 3: trigger the Whisper+LLM pipeline with the R2 key.
+    private func streamTranscribeJson(
+        r2Key: String,
+        sourceId: String,
+        language: String,
+        discipline: String?,
+        continuation: AsyncThrowingStream<TranscricaoSSEEvent, Error>.Continuation
+    ) async throws {
+        guard let url = URL(string: AppConfig.apiBaseURL + "/ai/transcribe") else {
+            throw APIError.invalidURL
+        }
+        var body: [String: Any] = [
+            "r2Key": r2Key,
+            "sourceId": sourceId,
+            "language": language,
+        ]
+        if let discipline = discipline, !discipline.isEmpty, discipline != "Auto-detectar" {
+            body["discipline"] = discipline
+        }
+        let jsonBody = try JSONSerialization.data(withJSONObject: body)
+
+        var didAttemptRefresh = false
+        for attempt in 0..<Self.maxRetries {
+            if attempt > 0 {
+                let delay = UInt64(pow(2.0, Double(attempt - 1)) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: delay)
+            }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            request.httpBody = jsonBody
+            request.timeoutInterval = 300
+            if let token = await self.tokenStore.token {
+                request.setValue("__Secure-better-auth.session_token=\(token)", forHTTPHeaderField: "Cookie")
+            }
+
+            let bytes: URLSession.AsyncBytes
+            let response: URLResponse
+            do {
+                (bytes, response) = try await self.session.bytes(for: request)
+            } catch {
+                if attempt == Self.maxRetries - 1 { throw APIError.networkError(error) }
+                continue
+            }
+            guard let http = response as? HTTPURLResponse else { throw APIError.unknown }
+
+            if http.statusCode == 401 {
+                if !didAttemptRefresh {
+                    didAttemptRefresh = true
+                    if await self.tokenRefresher.refreshSession() { continue }
+                }
+                if let handler = self.onUnauthorized { await handler() }
+                throw APIError.unauthorized
+            }
+            if !(200...299).contains(http.statusCode) {
+                if (500...599).contains(http.statusCode) && attempt < Self.maxRetries - 1 { continue }
+                throw APIError.serverError(http.statusCode)
+            }
+
+            try await self.consumeSSE(bytes: bytes, continuation: continuation)
+            return
+        }
+        throw APIError.unknown
+    }
+
+    /// Legacy multipart path — kept for older backends and local dev without R2.
+    private func streamTranscribeMultipart(
+        fileData: Data,
+        language: String,
+        discipline: String?,
+        continuation: AsyncThrowingStream<TranscricaoSSEEvent, Error>.Continuation
+    ) async throws {
+        let boundary = "VitaBoundary-\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        var body = Data()
+        body.append(formPart(boundary: boundary, name: "audio", filename: "audio.m4a",
+                             contentType: "audio/m4a", data: fileData))
+        body.append(formTextPart(boundary: boundary, name: "language", value: language))
+        if let discipline = discipline, !discipline.isEmpty, discipline != "Auto-detectar" {
+            body.append(formTextPart(boundary: boundary, name: "discipline", value: discipline))
+        }
+        body.append("--\(boundary)--\r\n".utf8Data)
+
+        guard let url = URL(string: AppConfig.apiBaseURL + "/ai/transcribe") else {
+            throw APIError.invalidURL
+        }
+        var didAttemptRefresh = false
+        for attempt in 0..<Self.maxRetries {
+            if attempt > 0 {
+                let delay = UInt64(pow(2.0, Double(attempt - 1)) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: delay)
+            }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            request.httpBody = body
+            request.timeoutInterval = 300
+            if let token = await self.tokenStore.token {
+                request.setValue("__Secure-better-auth.session_token=\(token)", forHTTPHeaderField: "Cookie")
+            }
+
+            let bytes: URLSession.AsyncBytes
+            let response: URLResponse
+            do {
+                (bytes, response) = try await self.session.bytes(for: request)
+            } catch {
+                if attempt == Self.maxRetries - 1 { throw APIError.networkError(error) }
+                continue
+            }
+            guard let http = response as? HTTPURLResponse else { throw APIError.unknown }
+
+            if http.statusCode == 401 {
+                if !didAttemptRefresh {
+                    didAttemptRefresh = true
+                    if await self.tokenRefresher.refreshSession() { continue }
+                }
+                if let handler = self.onUnauthorized { await handler() }
+                throw APIError.unauthorized
+            }
+            if !(200...299).contains(http.statusCode) {
+                if (500...599).contains(http.statusCode) && attempt < Self.maxRetries - 1 { continue }
+                throw APIError.serverError(http.statusCode)
+            }
+
+            try await self.consumeSSE(bytes: bytes, continuation: continuation)
+            return
+        }
+        throw APIError.unknown
+    }
+
+    /// Shared SSE consumer — reads `event:` / `data:` pairs and emits parsed events.
+    private func consumeSSE(
+        bytes: URLSession.AsyncBytes,
+        continuation: AsyncThrowingStream<TranscricaoSSEEvent, Error>.Continuation
+    ) async throws {
+        var eventType = ""
+        var dataLines: [String] = []
+        for try await line in bytes.lines {
+            if line.hasPrefix("event:") {
+                eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("data:") {
+                let content = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                dataLines.append(content)
+            } else if line.isEmpty, !dataLines.isEmpty {
+                let rawJSON = dataLines.joined(separator: "\n")
+                dataLines = []
+                if let event = Self.parse(type: eventType, data: rawJSON) {
+                    continuation.yield(event)
+                    switch event {
+                    case .complete, .error:
+                        continuation.finish()
+                        return
+                    default:
+                        break
+                    }
+                }
+                eventType = ""
+            }
+        }
+        continuation.finish()
     }
 
     // MARK: - Multipart Builder
@@ -384,6 +557,15 @@ actor TranscricaoClient {
         part.append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".utf8Data)
         part.append("Content-Type: \(contentType)\r\n\r\n".utf8Data)
         part.append(data)
+        part.append("\r\n".utf8Data)
+        return part
+    }
+
+    private func formTextPart(boundary: String, name: String, value: String) -> Data {
+        var part = Data()
+        part.append("--\(boundary)\r\n".utf8Data)
+        part.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".utf8Data)
+        part.append(value.utf8Data)
         part.append("\r\n".utf8Data)
         return part
     }

--- a/VitaAI/DesignSystem/Components/VitaMenuPopout.swift
+++ b/VitaAI/DesignSystem/Components/VitaMenuPopout.swift
@@ -77,9 +77,9 @@ struct VitaMenuPopout: View {
             menuDivider
 
             // Navigation items
-            menuItem(icon: "person.crop.circle", label: "Perfil", identifier: "menu_perfil") {
-                dismiss(); onProfile()
-            }
+            // "Perfil" intentionally omitted — the avatar header above already
+            // taps into onProfile() and the "Ver perfil" subtitle makes it
+            // clear. Having it twice was redundant (Rafael, 2026-04-22).
             menuItem(icon: "bell", label: "Notificações", identifier: "menu_notificacoes") {
                 dismiss(); onNotifications()
             }

--- a/VitaAI/Features/Onboarding/VitaMascot.swift
+++ b/VitaAI/Features/Onboarding/VitaMascot.swift
@@ -51,6 +51,10 @@ struct OrbMascot: View {
     // Staff/snake removed entirely on 2026-04-18 — Rafael called it ugly and
     // wanted the orb to stand on its own. Param kept for source compat (no-op).
     var showStaff: Bool = false
+    // When false, the orb's periodic "bounce" is suppressed. Useful for
+    // screens where the bounce competes with the user's task — e.g. the
+    // Transcrição recorder where the orb needs to look focused, not excited.
+    var bounceEnabled: Bool = true
 
     @State private var floatY: CGFloat = 0
     @State private var glowIntensity: Double = 0.3
@@ -487,7 +491,9 @@ struct OrbMascot: View {
             await withTaskGroup(of: Void.self) { group in
                 group.addTask { await self.eyeLookLoop() }
                 group.addTask { await self.blinkLoop() }
-                group.addTask { await self.bounceLoop() }
+                if self.bounceEnabled {
+                    group.addTask { await self.bounceLoop() }
+                }
                 group.addTask { await self.headTiltLoop() }
                 group.addTask { await self.idleDriftLoop() }
                 group.addTask { await self.magicPulseLoop() }

--- a/VitaAI/Features/Transcricao/TranscricaoControls.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoControls.swift
@@ -1,0 +1,342 @@
+import SwiftUI
+
+// MARK: - DisciplinePicker
+//
+// Replaces the horizontal scroll of chips (which cut off while scrolling).
+// A single compact chip that, on tap, opens a popover with:
+//   - "Auto-detectar" (default)
+//   - All user disciplines (current + completed)
+//   - "Outro..." → inline text field for a custom folder name
+//
+// Custom names land in `selectedDiscipline` just like any discipline, so
+// the recording gets grouped under its own folder in the list view.
+
+struct TranscricaoDisciplinePicker: View {
+    @Binding var selected: String
+    let disciplines: [String]
+    let disabled: Bool
+
+    @State private var isOpen = false
+    @State private var showCustomInput = false
+    @State private var customName = ""
+    @FocusState private var customFocused: Bool
+
+    private let autoLabel = "Auto-detectar"
+
+    var body: some View {
+        Button {
+            isOpen = true
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isAuto ? "sparkles" : "folder.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(abbreviateDiscipline(selected.isEmpty ? autoLabel : selected))
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .opacity(0.6)
+            }
+            .foregroundStyle(VitaColors.accentHover.opacity(0.92))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(VitaColors.accent.opacity(0.12))
+            )
+            .overlay(
+                Capsule()
+                    .stroke(VitaColors.accent.opacity(0.30), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(disabled ? 0.5 : 1)
+        .popover(isPresented: $isOpen, attachmentAnchor: .point(.bottom), arrowEdge: .top) {
+            pickerMenu
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    private var isAuto: Bool {
+        selected.isEmpty || selected == autoLabel
+    }
+
+    // MARK: - Popover menu
+
+    private var pickerMenu: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            pickerRow(label: autoLabel, icon: "sparkles", value: autoLabel, showCheck: isAuto)
+
+            if !disciplines.isEmpty {
+                divider
+                Text("MINHAS DISCIPLINAS")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(VitaColors.textWarm.opacity(0.45))
+                    .tracking(0.8)
+                    .padding(.horizontal, 14)
+                    .padding(.top, 10)
+                    .padding(.bottom, 4)
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(disciplines, id: \.self) { d in
+                            pickerRow(label: d, icon: "book.closed.fill", value: d, showCheck: selected == d)
+                        }
+                    }
+                }
+                .frame(maxHeight: 260)
+            }
+
+            divider
+
+            if showCustomInput {
+                customInputRow
+            } else {
+                Button {
+                    showCustomInput = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        customFocused = true
+                    }
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "folder.badge.plus")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(VitaColors.accentHover.opacity(0.8))
+                            .frame(width: 20)
+                        Text("Outro…")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Color.white.opacity(0.85))
+                        Spacer()
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(width: 260)
+        .background(popoverBackground)
+    }
+
+    private func pickerRow(label: String, icon: String, value: String, showCheck: Bool) -> some View {
+        Button {
+            selected = value
+            isOpen = false
+            showCustomInput = false
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                    .foregroundStyle(VitaColors.accentLight.opacity(0.70))
+                    .frame(width: 20)
+                Text(label)
+                    .font(.system(size: 13, weight: showCheck ? .semibold : .regular))
+                    .foregroundStyle(Color.white.opacity(showCheck ? 0.95 : 0.80))
+                    .lineLimit(1)
+                Spacer()
+                if showCheck {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(VitaColors.accentHover)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var customInputRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "folder.badge.plus")
+                .font(.system(size: 13))
+                .foregroundStyle(VitaColors.accentHover.opacity(0.85))
+            TextField("Nome da pasta", text: $customName)
+                .focused($customFocused)
+                .textInputAutocapitalization(.words)
+                .submitLabel(.done)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.white.opacity(0.95))
+                .onSubmit(applyCustom)
+            Button {
+                applyCustom()
+            } label: {
+                Text("OK")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(VitaColors.accentHover)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(Capsule().fill(VitaColors.accent.opacity(0.15)))
+            }
+            .buttonStyle(.plain)
+            .disabled(customName.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func applyCustom() {
+        let trimmed = customName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        selected = trimmed
+        customName = ""
+        showCustomInput = false
+        isOpen = false
+    }
+
+    // MARK: - Chrome
+
+    private var divider: some View {
+        Rectangle()
+            .fill(VitaColors.accent.opacity(0.10))
+            .frame(height: 1)
+            .padding(.horizontal, 8)
+    }
+
+    private var popoverBackground: some View {
+        ZStack {
+            Color.clear
+                .background(.ultraThinMaterial)
+            LinearGradient(
+                colors: [
+                    Color(red: 0.055, green: 0.043, blue: 0.035).opacity(0.92),
+                    Color(red: 0.035, green: 0.028, blue: 0.022).opacity(0.96),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            RoundedRectangle(cornerRadius: 0)
+                .stroke(VitaColors.accent.opacity(0.18), lineWidth: 0.5)
+        }
+    }
+}
+
+// MARK: - LanguagePicker (native Menu)
+
+struct TranscricaoLanguagePicker: View {
+    @Binding var selected: String
+    let disabled: Bool
+
+    struct Language: Identifiable, Equatable {
+        let code: String
+        let label: String
+        let flag: String
+        var id: String { code }
+    }
+
+    static let all: [Language] = [
+        .init(code: "pt", label: "Português",  flag: "🇧🇷"),
+        .init(code: "en", label: "English",    flag: "🇺🇸"),
+        .init(code: "es", label: "Español",    flag: "🇪🇸"),
+        .init(code: "fr", label: "Français",   flag: "🇫🇷"),
+        .init(code: "de", label: "Deutsch",    flag: "🇩🇪"),
+        .init(code: "it", label: "Italiano",   flag: "🇮🇹"),
+        .init(code: "la", label: "Latim",      flag: "📜"),
+    ]
+
+    private var current: Language {
+        Self.all.first { $0.code == selected } ?? Self.all[0]
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(Self.all) { lang in
+                Button {
+                    selected = lang.code
+                } label: {
+                    if selected == lang.code {
+                        Label("\(lang.flag) \(lang.label)", systemImage: "checkmark")
+                    } else {
+                        Text("\(lang.flag) \(lang.label)")
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Text(current.flag)
+                    .font(.system(size: 12))
+                Text(current.code.uppercased())
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(VitaColors.accentHover.opacity(0.88))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(VitaColors.accent.opacity(0.6))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(Color.white.opacity(0.05)))
+            .overlay(Capsule().stroke(VitaColors.accent.opacity(0.15), lineWidth: 1))
+        }
+        .disabled(disabled)
+        .opacity(disabled ? 0.5 : 1)
+    }
+}
+
+// MARK: - Pause/Resume Button
+
+struct TranscricaoPauseResumeButton: View {
+    let isPaused: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 6) {
+                Image(systemName: isPaused ? "play.fill" : "pause.fill")
+                    .font(.system(size: 10, weight: .bold))
+                Text(isPaused ? "Retomar" : "Pausar")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundStyle(VitaColors.accentHover.opacity(0.88))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Capsule().fill(VitaColors.accent.opacity(0.10)))
+            .overlay(Capsule().stroke(VitaColors.accent.opacity(0.22), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Shared helpers
+
+/// Shortens long discipline names for the picker chip + row labels.
+/// Shared with the filter chips in the recordings list.
+func abbreviateDiscipline(_ name: String) -> String {
+    let prepositions: Set<String> = ["de", "do", "da", "dos", "das", "em", "e", "a", "o", "na", "no", "para"]
+
+    let words: [String] = name.lowercased().split(separator: " ").compactMap { segment in
+        let w = String(segment)
+        if prepositions.contains(w) { return nil }
+        if w.allSatisfy({ "ivxlcdm".contains($0) }) && !w.isEmpty {
+            return w.uppercased()
+        }
+        return w.prefix(1).uppercased() + w.dropFirst()
+    }
+
+    let full = words.joined(separator: " ")
+    if full.count <= 18 { return full }
+
+    guard let first = words.first else { return full }
+    if words.count == 1 {
+        return String(first.prefix(16)) + "."
+    }
+
+    var result = first
+    if result.count > 12 {
+        result = String(first.prefix(4)) + "."
+    }
+
+    for i in 1..<words.count {
+        let w = words[i]
+        let candidate = result + " " + w
+        if candidate.count <= 18 {
+            result = candidate
+        } else if w.count <= 3 && w.allSatisfy({ "IVX".contains($0) }) {
+            result += " " + w
+        } else {
+            break
+        }
+    }
+    return result
+}

--- a/VitaAI/Features/Transcricao/TranscricaoRecorderContent.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoRecorderContent.swift
@@ -1,24 +1,25 @@
 import SwiftUI
 
-// MARK: - Recorder Area (timer + waveform + discipline chips + record button)
-
-// Pre-seeded waveform heights — avoids CGFloat.random causing layout thrash on every render
-private let waveformHeights: [CGFloat] = [8, 18, 28, 14, 34, 10, 24, 32, 12, 22, 30, 8,
-                                          20, 34, 16, 26, 10, 28, 18, 34, 12, 22, 8, 20]
+// MARK: - Recorder Area (timer + waveform + discipline/language pickers + record button)
 
 struct TranscricaoRecorderArea: View {
     let elapsedSeconds: Int
     let isRecording: Bool
+    let isPaused: Bool
+    let audioLevels: [Float]
     @Binding var selectedDiscipline: String
+    @Binding var selectedLanguage: String
     let disciplines: [String]
     let onToggle: () -> Void
+    let onPauseResume: () -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var wavePhase: Bool = false
 
     private var recorderButtonWidth: CGFloat {
         horizontalSizeClass == .regular ? 200 : 155
     }
+
+    private var isActive: Bool { isRecording || isPaused }
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -37,110 +38,143 @@ struct TranscricaoRecorderArea: View {
                     .shadow(color: isRecording ? VitaColors.accent.opacity(0.4) : .clear, radius: 24)
 
                 // Status label
-                Text(isRecording ? "Gravando..." : "Pronto para gravar")
+                Text(statusLabel)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(
-                        isRecording
+                        isActive
                             ? VitaColors.accentLight.opacity(0.70)
                             : Color.white.opacity(0.25)
                     )
                     .padding(.top, 2)
 
-                // Waveform bars — fixed heights, animated via phase toggle
-                HStack(spacing: 1.5) {
-                    ForEach(0..<24, id: \.self) { i in
-                        let baseH = waveformHeights[i]
-                        let altH  = waveformHeights[(i + 12) % 24]
-                        let h: CGFloat = isRecording ? (wavePhase ? baseH : altH) : 6
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(
-                                isRecording
-                                    ? LinearGradient(
-                                        colors: [VitaColors.accent.opacity(0.5), VitaColors.accentLight.opacity(0.85)],
-                                        startPoint: .bottom,
-                                        endPoint: .top
-                                      )
-                                    : LinearGradient(
-                                        colors: [VitaColors.accent.opacity(0.10)],
-                                        startPoint: .bottom,
-                                        endPoint: .top
-                                      )
-                            )
-                            .frame(width: 2.5, height: h)
-                            .animation(.easeInOut(duration: 0.35).delay(Double(i) * 0.02), value: wavePhase)
-                            .animation(.easeInOut(duration: 0.35), value: isRecording)
-                    }
-                }
-                .frame(height: 36)
-                .padding(.top, 8)
-                .onAppear {
-                    guard isRecording else { return }
-                    withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-                        wavePhase.toggle()
-                    }
-                }
-                .onChange(of: isRecording) { _, recording in
-                    if recording {
-                        withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-                            wavePhase.toggle()
-                        }
-                    }
-                }
+                // Live waveform — driven by the ViewModel's audioLevels.
+                // When idle or paused, bars drop to a subtle baseline so the
+                // user knows nothing's being captured.
+                LiveWaveformBars(levels: audioLevels, isActive: isRecording)
+                    .frame(height: 36)
+                    .padding(.top, 8)
 
-                // Discipline chips below waveform
-                TranscricaoDisciplineChips(
-                    disciplines: ["Auto-detectar"] + disciplines,
-                    selected: $selectedDiscipline,
-                    disabled: isRecording
-                )
-                .padding(.top, 4)
+                // Discipline + language pickers (always enabled, never during record)
+                HStack(spacing: 8) {
+                    TranscricaoDisciplinePicker(
+                        selected: $selectedDiscipline,
+                        disciplines: disciplines,
+                        disabled: isRecording
+                    )
+                    TranscricaoLanguagePicker(
+                        selected: $selectedLanguage,
+                        disabled: isRecording
+                    )
+                }
+                .padding(.top, 6)
 
-                // Stop button (only visible when recording)
-                if isRecording {
-                    Button(action: onToggle) {
-                        Text("Parar gravação")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(VitaColors.accentHover.opacity(0.85))
+                // Pause/Resume + Stop buttons while recording or paused
+                if isActive {
+                    HStack(spacing: 8) {
+                        TranscricaoPauseResumeButton(isPaused: isPaused, onTap: onPauseResume)
+
+                        Button(action: onToggle) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "stop.fill")
+                                    .font(.system(size: 10, weight: .bold))
+                                Text("Parar")
+                                    .font(.system(size: 11, weight: .semibold))
+                            }
+                            .foregroundStyle(VitaColors.accentHover.opacity(0.90))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
                             .frame(maxWidth: .infinity)
-                            .frame(height: 34)
-                            .background(VitaColors.accent.opacity(0.10))
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10)
-                                    .stroke(VitaColors.accent.opacity(0.18), lineWidth: 1)
+                            .background(
+                                LinearGradient(
+                                    colors: [VitaColors.accent.opacity(0.18), VitaColors.accent.opacity(0.10)],
+                                    startPoint: .top, endPoint: .bottom
+                                )
                             )
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(VitaColors.accent.opacity(0.30), lineWidth: 1))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                     .padding(.top, 8)
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
             }
 
-            // Right side: recorder image button
-            Button(action: {
-                if !isRecording { onToggle() }
-            }) {
+            // Right side: Vita mascot as the record button itself.
+            // Tap ALWAYS toggles — waking to record, tapping again to stop.
+            // Matches the "toque para acordar" pattern from onboarding.
+            Button(action: onToggle) {
                 VStack(spacing: 4) {
-                    VitaTypingMascot(isRecording: isRecording, size: recorderButtonWidth)
+                    VitaTypingMascot(isRecording: isActive, size: recorderButtonWidth)
 
-                    Text(isRecording ? "Gravando..." : "Toque para gravar")
+                    Text(mascotLabel)
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(
-                            isRecording
+                            isActive
                                 ? VitaColors.accentLight.opacity(0.70)
                                 : Color.white.opacity(0.22)
                         )
                 }
             }
             .buttonStyle(.plain)
+            .accessibilityLabel(isActive ? "Parar gravação" : "Iniciar gravação")
         }
         .padding(.bottom, 10)
     }
+
+    private var statusLabel: String {
+        if isPaused { return "Pausado" }
+        if isRecording { return "Gravando…" }
+        return "Pronto para gravar"
+    }
+
+    private var mascotLabel: String {
+        if isPaused { return "Toque para parar" }
+        if isRecording { return "Toque para parar" }
+        return "Toque para gravar"
+    }
 }
 
-// MARK: - Discipline Chips
+// MARK: - Live Waveform Bars
+//
+// Reads the ViewModel's audioLevels (length = TranscricaoViewModel.waveformBarCount)
+// and renders real-time bars. When idle/paused, bars drop to a subtle baseline.
 
-struct TranscricaoDisciplineChips: View {
+struct LiveWaveformBars: View {
+    let levels: [Float]
+    let isActive: Bool
+
+    private let minHeight: CGFloat = 4
+    private let maxHeight: CGFloat = 34
+
+    var body: some View {
+        HStack(spacing: 1.5) {
+            ForEach(Array(levels.enumerated()), id: \.offset) { _, level in
+                let h: CGFloat = isActive
+                    ? max(minHeight, minHeight + CGFloat(level) * (maxHeight - minHeight))
+                    : minHeight + 2
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(
+                        isActive
+                            ? LinearGradient(
+                                colors: [VitaColors.accent.opacity(0.55), VitaColors.accentLight.opacity(0.90)],
+                                startPoint: .bottom, endPoint: .top
+                              )
+                            : LinearGradient(
+                                colors: [VitaColors.accent.opacity(0.10)],
+                                startPoint: .bottom, endPoint: .top
+                              )
+                    )
+                    .frame(width: 2.5, height: h)
+                    .animation(.easeOut(duration: 0.12), value: h)
+            }
+        }
+    }
+}
+
+// MARK: - (legacy discipline chips — kept for recordings list filter, renamed)
+
+private struct LegacyChips: View {
     let disciplines: [String]
     @Binding var selected: String
     let disabled: Bool
@@ -515,60 +549,4 @@ struct TealGlassRecordingCard: View {
     }
 }
 
-// MARK: - Discipline Name Abbreviation
-
-/// Shortens long discipline names for chips.
-/// Strategy: title-case, drop prepositions, abbreviate to fit ≤16 chars.
-/// "FARMACOLOGIA MÉDICA I" → "Farmacologia I"
-/// "MEDICINA DE FAMÍLIA E COMUNIDADE" → "Med. Família"
-/// "PRÁTICAS MÉDICAS EM ATENÇÃO BÁSICA" → "Prát. Médicas"
-private func abbreviateDiscipline(_ name: String) -> String {
-    let prepositions: Set<String> = ["de", "do", "da", "dos", "das", "em", "e", "a", "o", "na", "no", "para"]
-
-    // Title-case words, skipping prepositions
-    let words: [String] = name.lowercased().split(separator: " ").compactMap { segment in
-        let w = String(segment)
-        // Drop prepositions entirely for abbreviation
-        if prepositions.contains(w) { return nil }
-        // Keep roman numerals uppercase
-        if w.allSatisfy({ "ivxlcdm".contains($0) }) && !w.isEmpty {
-            return w.uppercased()
-        }
-        return w.prefix(1).uppercased() + w.dropFirst()
-    }
-
-    // If the joined result is short enough, return as-is
-    let full = words.joined(separator: " ")
-    if full.count <= 16 { return full }
-
-    // Keep first word (possibly abbreviated) + second word abbreviated
-    guard let first = words.first else { return full }
-
-    if words.count == 1 {
-        // Single long word — truncate
-        return String(first.prefix(14)) + "."
-    }
-
-    // Try: first word + remaining as initials/short
-    var result = first
-    if result.count > 10 {
-        // Abbreviate first word too
-        result = String(first.prefix(4)) + "."
-    }
-
-    for i in 1..<words.count {
-        let w = words[i]
-        let candidate = result + " " + w
-        if candidate.count <= 16 {
-            result = candidate
-        } else {
-            // Roman numeral — always append
-            if w.count <= 3 && w.allSatisfy({ "IVX".contains($0) }) {
-                result += " " + w
-            }
-            break
-        }
-    }
-
-    return result
-}
+// `abbreviateDiscipline` moved to TranscricaoControls.swift (shared with pickers).

--- a/VitaAI/Features/Transcricao/TranscricaoScreen.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoScreen.swift
@@ -49,7 +49,8 @@ private struct TranscricaoContent: View {
 
     @Environment(\.appData) private var appData
     @State private var selectedMode: TranscricaoRecordingMode = .offline
-    @State private var selectedDiscipline: String = "Auto-detectar"
+    // `selectedDiscipline` lives on the ViewModel so it flows into the upload
+    // payload (R2 metadata + backend) without a second piece of state.
     @State private var selectedFilter: String? = nil
     @State private var selectedRecording: TranscricaoEntry? = nil
 
@@ -113,15 +114,31 @@ private struct TranscricaoContent: View {
                                     .opacity(isProcessing ? 0.5 : 1.0)
 
                                 TranscricaoRecorderArea(
-                                    elapsedSeconds: viewModel.phase == .recording ? viewModel.elapsedSeconds : 0,
+                                    elapsedSeconds: (viewModel.phase == .recording || viewModel.phase == .paused) ? viewModel.elapsedSeconds : 0,
                                     isRecording: viewModel.phase == .recording,
-                                    selectedDiscipline: $selectedDiscipline,
+                                    isPaused: viewModel.phase == .paused,
+                                    audioLevels: viewModel.audioLevels,
+                                    selectedDiscipline: Binding(
+                                        get: { viewModel.selectedDiscipline },
+                                        set: { viewModel.selectedDiscipline = $0 }
+                                    ),
+                                    selectedLanguage: Binding(
+                                        get: { viewModel.selectedLanguage },
+                                        set: { viewModel.selectedLanguage = $0 }
+                                    ),
                                     disciplines: disciplines,
                                     onToggle: {
-                                        if viewModel.phase == .recording {
+                                        if viewModel.phase == .recording || viewModel.phase == .paused {
                                             viewModel.stopRecording()
                                         } else {
                                             Task { await viewModel.startRecording() }
+                                        }
+                                    },
+                                    onPauseResume: {
+                                        if viewModel.phase == .recording {
+                                            viewModel.pauseRecording()
+                                        } else if viewModel.phase == .paused {
+                                            viewModel.resumeRecording()
                                         }
                                     }
                                 )

--- a/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
@@ -21,6 +21,7 @@ final class TranscricaoViewModel {
     enum Phase: Equatable {
         case idle
         case recording
+        case paused
         case uploading
         case transcribing
         case summarizing
@@ -29,12 +30,26 @@ final class TranscricaoViewModel {
         case error
     }
 
+    /// Number of bars in the live waveform. Kept as a small power-of-2 so the
+    /// tap buffer can cheaply push into it without allocations.
+    static let waveformBarCount = 24
+
     // MARK: - Exposed State
 
     private(set) var phase: Phase = .idle
     private(set) var elapsedSeconds: Int = 0
     private(set) var progressPercent: Int = 0
     private(set) var progressStage: String = ""
+    /// Live waveform levels (0.0…1.0), length = `waveformBarCount`.
+    /// Oldest sample is at index 0, newest at the end. Updated from the audio
+    /// tap while recording.
+    private(set) var audioLevels: [Float] = Array(repeating: 0, count: waveformBarCount)
+    /// User-selected language code for Whisper (defaults to pt-BR audio input).
+    var selectedLanguage: String = "pt"
+    /// User-selected discipline for the recording. "Auto-detectar" means the
+    /// server will classify from context (future Fase 2) — today it's just
+    /// stored as metadata and used by the filter picker.
+    var selectedDiscipline: String = "Auto-detectar"
     /// Real-time SFSpeechRecognizer partial transcript shown during recording.
     private(set) var liveTranscript: String = ""
     private(set) var transcript: String = ""
@@ -51,6 +66,7 @@ final class TranscricaoViewModel {
     private var api: VitaAPI?
     private var gamificationEvents: GamificationEventManager?
     private var audioEngine: AVAudioEngine?
+    private var activeOutputFile: AVAudioFile?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "pt-BR"))
@@ -146,6 +162,64 @@ final class TranscricaoViewModel {
         summary = ""
         flashcards = []
         errorMessage = nil
+        audioLevels = Array(repeating: 0, count: Self.waveformBarCount)
+    }
+
+    /// Pause recording without finalizing the file. Removes the tap so no more
+    /// samples flow in, pauses the timer, keeps the AVAudioFile + engine alive
+    /// so resume continues into the same m4a.
+    func pauseRecording() {
+        guard phase == .recording else { return }
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        timerTask?.cancel()
+        timerTask = nil
+        phase = .paused
+    }
+
+    /// Resume from `.paused`. Re-installs the tap on the same node so buffers
+    /// flow back into the existing AVAudioFile and the SFSpeechRecognizer
+    /// request (which was never cancelled).
+    func resumeRecording() {
+        guard phase == .paused,
+              let engine = audioEngine,
+              let outputFile = activeOutputFile,
+              let request = recognitionRequest else { return }
+        let inputNode = engine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [outputFile, request, weak self] buffer, _ in
+            try? outputFile.write(from: buffer)
+            request.append(buffer)
+            let level = Self.averageLevel(buffer)
+            Task { @MainActor [weak self] in self?.appendAudioLevel(level) }
+        }
+        phase = .recording
+        startTimer()
+    }
+
+    // MARK: - Waveform helpers
+
+    /// Shift audio levels left by one and append the new sample to the end.
+    /// Called on MainActor from the tap at whatever cadence iOS decides
+    /// (~20–40 Hz with a 4096-frame buffer at 44.1 kHz). Cheap O(N) array op.
+    private func appendAudioLevel(_ raw: Float) {
+        // Soft-knee curve so quiet speech still shows visible bars and loud
+        // peaks don't saturate into a flat line.
+        let normalized = min(1, max(0, sqrtf(raw) * 2.4))
+        if audioLevels.count == Self.waveformBarCount {
+            audioLevels.removeFirst()
+        }
+        audioLevels.append(normalized)
+    }
+
+    /// Linear average of absolute sample values across the first channel.
+    /// Fast, lock-free, no FFT. Called from the realtime audio thread.
+    nonisolated private static func averageLevel(_ buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData?[0] else { return 0 }
+        let frames = Int(buffer.frameLength)
+        guard frames > 0 else { return 0 }
+        var sum: Float = 0
+        for i in 0..<frames { sum += abs(channelData[i]) }
+        return sum / Float(frames)
     }
 
     // MARK: - Permissions
@@ -177,18 +251,34 @@ final class TranscricaoViewModel {
     // MARK: - Audio Capture
 
     private func beginAudioCapture(outputURL: URL) throws {
+        // Activate audio session FIRST — inputNode.outputFormat returns 0 Hz otherwise,
+        // which causes installTap to throw an uncatchable NSException and terminate the app.
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let inputFormat = inputNode.outputFormat(forBus: 0)
 
-        // Write to disk (AAC/m4a) — same format as Android AudioRecorder
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            try? session.setActive(false)
+            throw NSError(domain: "Transcricao", code: -1, userInfo: [NSLocalizedDescriptionKey: "Microfone indisponível (formato inválido). Tente novamente."])
+        }
+
+        // Write to disk (AAC/m4a). Channel count MUST match the tap buffer
+        // (inputFormat.channelCount) — if the file is 1ch but the buffer is
+        // 2ch, every AVAudioFile.write(from:) returns error -50 and the file
+        // is silently empty. Whisper handles stereo fine; downmix is not
+        // worth the AVAudioConverter dance here.
         let fileSettings: [String: Any] = [
             AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
             AVSampleRateKey: inputFormat.sampleRate,
-            AVNumberOfChannelsKey: min(inputFormat.channelCount, 1),
+            AVNumberOfChannelsKey: Int(inputFormat.channelCount),
             AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
         ]
         let outputFile = try AVAudioFile(forWriting: outputURL, settings: fileSettings)
+        activeOutputFile = outputFile
 
         // SFSpeechRecognizer for live partial transcript
         let request = SFSpeechAudioBufferRecognitionRequest()
@@ -196,16 +286,16 @@ final class TranscricaoViewModel {
         request.requiresOnDeviceRecognition = false
         recognitionRequest = request
 
-        // Single tap: write samples to disk AND feed speech recognizer
-        // Capture `outputFile` and `request` by value to avoid actor isolation issues
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [outputFile, request] buffer, _ in
+        // Single tap: write samples to disk, feed speech recognizer, AND
+        // compute waveform power for the live bars. Pushing levels back via a
+        // weak MainActor hop keeps the realtime audio thread lock-free.
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [outputFile, request, weak self] buffer, _ in
             try? outputFile.write(from: buffer)
             request.append(buffer)
+            let level = Self.averageLevel(buffer)
+            Task { @MainActor [weak self] in self?.appendAudioLevel(level) }
         }
 
-        let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
-        try session.setActive(true, options: .notifyOthersOnDeactivation)
         try engine.start()
         audioEngine = engine
 
@@ -225,6 +315,7 @@ final class TranscricaoViewModel {
         audioEngine?.inputNode.removeTap(onBus: 0)
         audioEngine?.stop()
         audioEngine = nil
+        activeOutputFile = nil
         recognitionRequest = nil
         recognitionTask = nil
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
@@ -252,7 +343,11 @@ final class TranscricaoViewModel {
             "duration_seconds": Int(Date().timeIntervalSince(recordingStartDate)),
         ])
         do {
-            for try await event in await client.uploadAndStream(fileURL: fileURL) {
+            for try await event in await client.uploadAndStream(
+                fileURL: fileURL,
+                language: selectedLanguage,
+                discipline: selectedDiscipline
+            ) {
                 switch event {
                 case .progress(let stage, let percent):
                     progressPercent = percent

--- a/VitaAI/Features/Transcricao/VitaTypingMascot.swift
+++ b/VitaAI/Features/Transcricao/VitaTypingMascot.swift
@@ -1,85 +1,263 @@
 import SwiftUI
 
-/// Mascote do Vita "digitando" enquanto a transcrição está ativa.
+/// Mascote do Vita na área de gravação da transcrição.
 ///
-/// Visual layering, top → bottom:
-/// 1. `btn-transcricao` (mascote orb gold, já existente)
-/// 2. Keyboard glyph (SF Symbol `keyboard.fill`) abaixo do mascote
-/// 3. Cursor piscante (barra vertical) à direita do teclado
+/// Filosofia: o Vita dorme até você tocar pra gravar, aí ele acorda e um
+/// teclado "voa" do nada pra frente dele — a transcrição é um ato do próprio
+/// Vita, não uma UI genérica. Inspirado no SleepStep do onboarding
+/// ("toque para acordar").
 ///
-/// Comportamento:
-/// - `isRecording == false` → estático, igual ao mascote original
-/// - `isRecording == true`  → cursor pisca 800ms on/off, teclado pulsa
-///   (scale 1.0 → 0.94 → 1.0) em loop 600ms, simulando digitação
-/// - Respeita `UIAccessibility.isReduceMotionEnabled`: sem animações
+/// Estados:
+/// - `isRecording == false` → `OrbMascot(.sleeping)` — orb fechado, aura
+///   discreta, sem teclado.
+/// - `isRecording == true`  → `OrbMascot(.thinking)` — olhos focados, aura
+///   ativa. Teclado voa de baixo com spring, pousa logo abaixo do orb,
+///   fica flutuando (±4pt) e teclas pulsam simulando digitação.
+///
+/// O orb usa `bounceEnabled: false` durante gravação pra não pular —
+/// Rafael pediu: "tem que parecer focado, não excitado".
+///
+/// Entrada/saída do teclado:
+/// - Entrada: offset y = +size*0.55 (fora da view), rotate 30°, scale 0.5,
+///   opacity 0 → pousa em y = -size*0.04, rotate 0°, scale 1, opacity 1
+///   via spring 0.55s.
+/// - Saída: sobe, rotate -15°, scale 0.8, opacity 0 em 0.35s easeIn.
+///
+/// Respeita `accessibilityReduceMotion`: animações de flutuação/tecla
+/// desligam. OrbMascot respeita internamente.
 struct VitaTypingMascot: View {
     let isRecording: Bool
     let size: CGFloat
 
-    @State private var cursorVisible = true
-    @State private var keyPressed = false
+    @State private var keyboardFloatY: CGFloat = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // Orb fills about 62% of the reserved width — leaves room for aura glow
+    // and the keyboard below without clipping.
+    private var orbSize: CGFloat { size * 0.62 }
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            Image("btn-transcricao")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: size)
-                .shadow(color: VitaColors.accent.opacity(0.30), radius: 20)
-                .opacity(isRecording ? 0.85 : 1.0)
-                .scaleEffect(isRecording ? 1.05 : 1.0)
-                .animation(.easeInOut(duration: 0.4), value: isRecording)
+            OrbMascot(
+                palette: .vita,
+                state: isRecording ? .thinking : .sleeping,
+                size: orbSize,
+                bounceEnabled: false
+            )
+            .frame(width: size, height: size)
+            .animation(.easeInOut(duration: 0.5), value: isRecording)
 
             if isRecording {
-                keyboardStrip
-                    .offset(y: size * 0.08)
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                VitaMiniKeyboard(size: size * 0.55, reduceMotion: reduceMotion)
+                    .offset(y: -size * 0.02 + keyboardFloatY)
+                    .transition(
+                        .asymmetric(
+                            insertion: .modifier(
+                                active: KeyboardEntryModifier(progress: 0, size: size),
+                                identity: KeyboardEntryModifier(progress: 1, size: size)
+                            ),
+                            removal: .opacity
+                                .combined(with: .scale(scale: 0.8))
+                                .combined(with: .offset(y: -size * 0.3))
+                        )
+                    )
             }
         }
-        .frame(width: size)
-        .onAppear { startAnimations() }
+        .frame(width: size, height: size)
+        .onAppear { startFloat() }
         .onChange(of: isRecording) { _, recording in
-            if recording { startAnimations() }
+            if recording { startFloat() }
         }
+        .animation(.spring(response: 0.55, dampingFraction: 0.72), value: isRecording)
     }
 
-    private var keyboardStrip: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "keyboard.fill")
-                .font(.system(size: size * 0.18, weight: .regular))
-                .foregroundStyle(VitaColors.accentLight.opacity(0.85))
-                .scaleEffect(keyPressed ? 0.94 : 1.0)
-                .shadow(color: VitaColors.accent.opacity(0.45), radius: 6)
-
-            RoundedRectangle(cornerRadius: 1)
-                .fill(VitaColors.accentLight.opacity(cursorVisible ? 0.9 : 0))
-                .frame(width: 2, height: size * 0.16)
-                .shadow(color: VitaColors.accent.opacity(0.6), radius: 4)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(
-            Capsule()
-                .fill(Color.black.opacity(0.45))
-                .overlay(
-                    Capsule().stroke(VitaColors.accent.opacity(0.18), lineWidth: 1)
-                )
-        )
-    }
-
-    private func startAnimations() {
+    private func startFloat() {
         guard isRecording, !reduceMotion else {
-            cursorVisible = true
-            keyPressed = false
+            keyboardFloatY = 0
             return
         }
-        withAnimation(.easeInOut(duration: 0.4).repeatForever(autoreverses: true)) {
-            cursorVisible.toggle()
+        withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+            keyboardFloatY = -4
         }
-        withAnimation(.easeInOut(duration: 0.3).repeatForever(autoreverses: true)) {
-            keyPressed.toggle()
+    }
+}
+
+/// Custom mini-keyboard drawn in SwiftUI. No SF Symbol — rendered in the
+/// Vita universe (gold gradient, glass base, inner glow). One key "press"
+/// animation cycles randomly through the keys while recording to sell
+/// "Vita digitando".
+private struct VitaMiniKeyboard: View {
+    let size: CGFloat
+    let reduceMotion: Bool
+
+    // 3 rows of keys. Row 3 has a wider spacebar at the end.
+    private let row1 = 8
+    private let row2 = 7
+    private let row3 = 5  // 4 normal + spacebar
+
+    @State private var activeKey: KeyID? = nil
+
+    private var padding: CGFloat { size * 0.065 }
+    private var keySpacing: CGFloat { size * 0.022 }
+    private var keyRadius: CGFloat { size * 0.035 }
+    private var rowHeight: CGFloat { size * 0.16 }
+
+    var body: some View {
+        VStack(spacing: keySpacing) {
+            row(count: row1, rowIndex: 0)
+            row(count: row2, rowIndex: 1)
+            row3View
         }
+        .padding(.horizontal, padding)
+        .padding(.vertical, padding * 0.9)
+        .background(keyboardBase)
+        .onAppear { if !reduceMotion { startTypingLoop() } }
+    }
+
+    // MARK: - Rows
+
+    private func row(count: Int, rowIndex: Int) -> some View {
+        HStack(spacing: keySpacing) {
+            ForEach(0..<count, id: \.self) { col in
+                keyCap(id: KeyID(row: rowIndex, col: col), isSpace: false)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .frame(height: rowHeight)
+    }
+
+    private var row3View: some View {
+        HStack(spacing: keySpacing) {
+            keyCap(id: KeyID(row: 2, col: 0), isSpace: false).frame(width: rowHeight * 0.95)
+            keyCap(id: KeyID(row: 2, col: 1), isSpace: false).frame(width: rowHeight * 0.95)
+            keyCap(id: KeyID(row: 2, col: 2), isSpace: true).frame(maxWidth: .infinity)
+            keyCap(id: KeyID(row: 2, col: 3), isSpace: false).frame(width: rowHeight * 0.95)
+            keyCap(id: KeyID(row: 2, col: 4), isSpace: false).frame(width: rowHeight * 0.95)
+        }
+        .frame(height: rowHeight)
+    }
+
+    // MARK: - Key
+
+    @ViewBuilder
+    private func keyCap(id: KeyID, isSpace: Bool) -> some View {
+        let active = activeKey == id
+        RoundedRectangle(cornerRadius: keyRadius, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: active
+                        ? [VitaColors.accentLight.opacity(0.95), VitaColors.accent.opacity(0.65)]
+                        : [VitaColors.accent.opacity(0.42), VitaColors.accentDark.opacity(0.30)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: keyRadius, style: .continuous)
+                    .stroke(
+                        LinearGradient(
+                            colors: active
+                                ? [VitaColors.accentLight.opacity(0.9), VitaColors.accent.opacity(0.4)]
+                                : [VitaColors.accent.opacity(0.45), VitaColors.accentDark.opacity(0.15)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: 0.6
+                    )
+            )
+            // Tiny top highlight — sells the "cap" look
+            .overlay(alignment: .top) {
+                RoundedRectangle(cornerRadius: keyRadius, style: .continuous)
+                    .fill(Color.white.opacity(active ? 0.45 : 0.18))
+                    .frame(height: rowHeight * 0.18)
+                    .padding(.horizontal, size * 0.008)
+                    .padding(.top, size * 0.006)
+                    .blur(radius: 0.4)
+                    .mask(RoundedRectangle(cornerRadius: keyRadius, style: .continuous))
+            }
+            .scaleEffect(active ? 0.92 : 1.0)
+            .shadow(color: active ? VitaColors.accent.opacity(0.55) : .clear, radius: 4)
+            .animation(.easeInOut(duration: 0.18), value: active)
+            .frame(height: rowHeight * (isSpace ? 0.80 : 1.0))
+    }
+
+    // MARK: - Base
+
+    private var keyboardBase: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.08, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.08, green: 0.06, blue: 0.035).opacity(0.85),
+                            Color(red: 0.04, green: 0.03, blue: 0.02).opacity(0.92),
+                        ],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+            RoundedRectangle(cornerRadius: size * 0.08, style: .continuous)
+                .stroke(
+                    LinearGradient(
+                        colors: [VitaColors.accent.opacity(0.55), VitaColors.accent.opacity(0.15)],
+                        startPoint: .top, endPoint: .bottom
+                    ),
+                    lineWidth: 0.8
+                )
+            // Inner top-edge glow (like a macbook keyboard underlit)
+            RoundedRectangle(cornerRadius: size * 0.08, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                .blur(radius: 0.5)
+                .offset(y: -0.5)
+        }
+        .shadow(color: VitaColors.accent.opacity(0.28), radius: 12)
+        .shadow(color: .black.opacity(0.55), radius: 6, y: 3)
+    }
+
+    // MARK: - Typing loop
+
+    private func startTypingLoop() {
+        Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(Int.random(in: 90...220)))
+                let rowCandidates = [row1, row2, row3]
+                let row = Int.random(in: 0..<3)
+                let col = Int.random(in: 0..<rowCandidates[row])
+                activeKey = KeyID(row: row, col: col)
+                try? await Task.sleep(for: .milliseconds(Int.random(in: 90...160)))
+                activeKey = nil
+            }
+        }
+    }
+
+    struct KeyID: Equatable {
+        let row: Int
+        let col: Int
+    }
+}
+
+/// Fly-in transition for the keyboard: rises from below, rotates into place,
+/// and springs to full opacity. Drives everything off a single 0→1 progress
+/// value so SwiftUI can animate it as a single transition.
+private struct KeyboardEntryModifier: ViewModifier, Animatable {
+    var progress: Double
+    let size: CGFloat
+
+    var animatableData: Double {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        let t = max(0, min(1, progress))
+        let offsetY = (1 - t) * size * 0.55
+        let rotation = Angle.degrees((1 - t) * 30)
+        let scale = 0.5 + 0.5 * t
+        let opacity = t
+        content
+            .opacity(opacity)
+            .scaleEffect(scale)
+            .rotationEffect(rotation)
+            .offset(y: offsetY)
     }
 }
 

--- a/VitaAI/Info.plist
+++ b/VitaAI/Info.plist
@@ -47,6 +47,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
+		<string>audio</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/VitaAI/Navigation/AppRouter.swift
+++ b/VitaAI/Navigation/AppRouter.swift
@@ -314,13 +314,13 @@ struct MainTabView: View {
                 VitaMenuPopout(
                     userName: authManager.userName,
                     userImageURL: authManager.userImage.flatMap(URL.init(string:)),
-                    onProfile: { router.navigate(to: .profile) },
+                    onProfile: { router.navigateFromMenu(to: .profile) },
                     onNotifications: { showMenuPopout = false; showNotifPopout = true },
-                    onAgenda: { router.navigate(to: .agenda) },
-                    onConfiguracoes: { router.navigate(to: .configuracoes) },
-                    onAppearance: { router.navigate(to: .appearance) },
-                    onConnections: { router.navigate(to: .connections) },
-                    onPaywall: { router.navigate(to: .paywall) },
+                    onAgenda: { router.navigateFromMenu(to: .agenda) },
+                    onConfiguracoes: { router.navigateFromMenu(to: .configuracoes) },
+                    onAppearance: { router.navigateFromMenu(to: .appearance) },
+                    onConnections: { router.navigateFromMenu(to: .connections) },
+                    onPaywall: { router.navigateFromMenu(to: .paywall) },
                     onLogout: { Task { await authManager.logout() } },
                     onDismiss: { showMenuPopout = false }
                 )
@@ -403,14 +403,48 @@ struct MainTabView: View {
         switch router.selectedTab {
         case .home:
             DashboardScreen(
-                onNavigateToFlashcards: { router.navigate(to: .flashcardHome()) },
-                onNavigateToSimulados: { router.navigate(to: .simuladoHome) },
+                // Breadcrumb hierarchy: Flashcards/Simulados/QBank/Transcrição/Atlas
+                // belong under Estudos — switch tab so the crumb reads
+                // "Home > Estudos > Flashcards" instead of "Home > Flashcards".
+                onNavigateToFlashcards: {
+                    router.selectedTab = .estudos
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .flashcardHome())
+                    }
+                },
+                onNavigateToSimulados: {
+                    router.selectedTab = .estudos
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .simuladoHome)
+                    }
+                },
                 onNavigateToPdfs: { router.selectedTab = .estudos },
-                onNavigateToMaterials: { router.navigate(to: .qbank) },
-                onNavigateToTranscricao: { router.navigate(to: .transcricao) },
-                onNavigateToAtlas3D: { router.navigate(to: .atlas3D) },
+                onNavigateToMaterials: {
+                    router.selectedTab = .estudos
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .qbank)
+                    }
+                },
+                onNavigateToTranscricao: {
+                    router.selectedTab = .estudos
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .transcricao)
+                    }
+                },
+                onNavigateToAtlas3D: {
+                    router.selectedTab = .estudos
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .atlas3D)
+                    }
+                },
                 onNavigateToDisciplineDetail: { id, name in router.navigateToDiscipline(id: id, name: name) },
-                onNavigateToTrabalhos: { router.navigate(to: .trabalhos) },
+                // Trabalhos lives under Faculdade (provas/agenda/trabalhos group).
+                onNavigateToTrabalhos: {
+                    router.selectedTab = .faculdade
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        router.navigate(to: .trabalhos)
+                    }
+                },
                 onSubtitleLoaded: { subtitle in dashboardSubtitle = subtitle }
             )
         case .estudos:

--- a/VitaAI/Navigation/Router.swift
+++ b/VitaAI/Navigation/Router.swift
@@ -25,8 +25,24 @@ final class Router {
     }
 
     func navigate(to route: Route) {
+        // Dedup: no-op if the current top of the stack is the same route.
+        // Prevents breadcrumb spam like "Home > Perfil > Perfil > Perfil"
+        // when the same menu item or destination is tapped repeatedly.
+        if routeStack.last == route { return }
         path.append(route)
         routeStack.append(route)
+    }
+
+    /// Navigate from the global menu popout (Perfil, Configurações, Conectores, …).
+    /// These destinations are conceptually modal — unrelated to whatever tab or
+    /// sub-page the user was on. Reset the stack to home root first so the
+    /// breadcrumb reads `Home > Perfil` instead of `Home > Flashcards > Perfil`.
+    func navigateFromMenu(to route: Route) {
+        popToRoot()
+        selectedTab = .home
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [self] in
+            navigate(to: route)
+        }
     }
 
     func goBack() {


### PR DESCRIPTION
## Why

Full Transcrição overhaul for Pato aula 2026-04-23. Fixes two crash-class bugs, gives the feature the real Vita mascote, routes audio through the new R2 direct-upload flow from [vitaai-web#155](https://github.com/by-mav/vitaai-web/pull/155).

## Crash / data-loss fixes

- **AVAudioSession activated BEFORE `outputFormat(forBus:)`** — previously the session was only activated after the tap was installed, so input format came back 0 Hz / 2 ch and `installTap` threw the uncatchable `IsFormatSampleRateAndChannelCountValid` exception. The app terminated before Rafael ever saw the record screen.
- **AVAudioFile channel count matches tap buffer exactly** — old `min(channelCount, 1)` forced the file to 1 ch while buffers were 2 ch. Every `AVAudioFile.write(from:)` silently returned `error -50` and the m4a came out empty. Whisper handles stereo fine.

## Vita mascote é o botão

`VitaTypingMascot` now renders the real `OrbMascot` (gold 3D glass orb from LoginScreen), not `btn-transcricao` asset. Tap the orb to toggle recording — same "toque para acordar" pattern as onboarding `SleepStep`.

- Idle:      `OrbMascot(state: .sleeping)`
- Recording: `OrbMascot(state: .thinking)` + custom SwiftUI keyboard flies in from below (spring 0.55 s, rotate 30°→0°, scale 0.5→1.0), levitates ±4pt, keys pulse at random 90–220 ms. Rafael: "um desenho no nivel do vita" — no SF Symbol.
- Stopping:  keyboard flies out, orb returns to sleep.
- `OrbMascot.bounceEnabled = false` so the orb stays focused.

## Gold-standard recorder UX

- **`TranscricaoDisciplinePicker`** — popover replaces the horizontal scroll of chips that Rafael kept accidentally cutting off. Lists "Auto-detectar" + user's disciplines + "Outro…" with inline text field for a custom folder name.
- **`TranscricaoLanguagePicker`** — native Menu with pt/en/es/fr/de/it/la. Value flows to Whisper (previously hardcoded).
- **Live waveform is REAL** — the tap computes `averageLevel` per buffer into a 24-sample ring buffer. Old fake pre-seeded pulse made people think the mic was dead.
- **Pause/resume** — new `Phase.paused`, re-installs the tap on the same `AVAudioFile` + still-alive `SFSpeechRecognizer` so class intervalo doesn't split the recording.
- **`UIBackgroundModes: audio`** — gravação survives a trip to WhatsApp mid-aula.

## R2 direct upload

`TranscricaoClient.uploadAndStream` now does a 3-step flow:

1. `POST /api/audio/upload-url` → `{r2Key, sourceId, presignedPutUrl}`
2. `PUT` the m4a straight to Cloudflare R2 edge (global PoPs)
3. `POST /api/ai/transcribe` with JSON `{r2Key, sourceId, language, discipline}` — SSE stream

Falls back to legacy multipart if step 1 or 2 fails. Both paths share the SSE consumer.

Gains: 100 MB cap (1h aula), VPS never buffers 50 MB in RAM, áudio persists in R2.

## Navigation fixes (from earlier today's session)

- Menu popout: removed duplicated "Perfil" entry (avatar already taps `onProfile`). `Router.navigateFromMenu(to:)` resets the stack before pushing, so "Home > Flashcards > Perfil" → "Home > Perfil".
- `Router.navigate(to:)` dedupes — tapping the same destination twice is a no-op.
- Dashboard Flashcards/Simulados/Transcrição/QBank/Atlas3D switch to Estudos tab before push → "Home > Estudos > Flashcards". Trabalhos switches to Faculdade.

## Test plan

- [ ] Login Google (rafaelfloureiro93@rede.ulbra.br) in prod TestFlight build
- [ ] Tap Transcrição in Home dashboard → breadcrumb: `Home > Estudos > Transcrição`
- [ ] Tap the sleeping Vita → orb wakes (`.thinking`), keyboard flies in
- [ ] Speak 15 s → live waveform reflects voice levels, SFSpeechRecognizer shows partial transcript
- [ ] Tap pause → timer stops, keyboard stays, bars drop to baseline
- [ ] Tap resume → recording continues into same m4a
- [ ] Open DisciplinePicker → pick "Outro…" → type "Patologia" → apply
- [ ] Switch idioma picker to 🇺🇸 EN to verify passthrough (then back to PT)
- [ ] Tap Parar → 3-step R2 upload flow (check server log `POST /api/audio/upload-url` then PUT to R2 then `POST /api/ai/transcribe` with `r2Key`)
- [ ] Fallback sanity: block `/api/audio/upload-url` → confirms multipart legacy path still works
- [ ] Swipe to WhatsApp during recording → return in 30 s → timer kept counting (background audio mode)

Closes (partial) [vitaai-ios#87](https://github.com/by-mav/vitaai-ios/issues/87) Fase 1 (DisciplinePicker, idioma, waveform real, pause/resume, background audio, channel fix, Vita mascote) + Fase 3.2 (R2 upload).

Depends on: [by-mav/vitaai-web#155](https://github.com/by-mav/vitaai-web/pull/155) merged + deployed for the R2 path to work. Multipart fallback keeps the feature working against older backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)