### PR TITLE
fix(transcribe): SSE parser + lifecycle + detail actions

### DIFF
--- a/VitaAI/Core/Network/HTTPClient.swift
+++ b/VitaAI/Core/Network/HTTPClient.swift
@@ -242,6 +242,12 @@ actor HTTPClient {
         try await request("PATCH", path: path, body: body)
     }
 
+    /// Fire-and-forget PATCH (204 No Content). Use when the server returns
+    /// no body and we just want to know it succeeded.
+    func patch(_ path: String, body: (any Encodable)? = nil) async throws {
+        let _: EmptyResponse = try await request("PATCH", path: path, body: body)
+    }
+
     func delete(_ path: String) async throws {
         let _: EmptyResponse = try await request("DELETE", path: path)
     }

--- a/VitaAI/Core/Network/TranscricaoClient.swift
+++ b/VitaAI/Core/Network/TranscricaoClient.swift
@@ -112,9 +112,12 @@ struct StudioSourceMetadata: Decodable {
     let segments: [WhisperSegment]?
     let audioFileId: String?
     let audioR2Key: String?
+    /// Short-lived presigned R2 GET URL for the audio file. Backend attaches
+    /// it on GET /api/studio/sources/:id so AVPlayer can stream directly.
+    let audioUrl: String?
 
     enum CodingKeys: String, CodingKey {
-        case duration, fileName, fileSize, whisperModel, segments, audioFileId, audioR2Key
+        case duration, durationSeconds, fileName, fileSize, whisperModel, segments, audioFileId, audioR2Key, audioUrl
     }
 
     init(from decoder: Decoder) throws {
@@ -125,14 +128,23 @@ struct StudioSourceMetadata: Decodable {
         segments = try c.decodeIfPresent([WhisperSegment].self, forKey: .segments)
         audioFileId = try c.decodeIfPresent(String.self, forKey: .audioFileId)
         audioR2Key = try c.decodeIfPresent(String.self, forKey: .audioR2Key)
+        audioUrl = try c.decodeIfPresent(String.self, forKey: .audioUrl)
 
-        // duration can be Double (seconds) or String ("~60min")
-        if let d = try? c.decodeIfPresent(Double.self, forKey: .duration) {
+        // `duration` is the legacy key and may be Double (seconds) or String
+        // ("~60min"). The new backend also writes `durationSeconds` directly —
+        // we prefer that when present.
+        let rawDurationSeconds = try? c.decodeIfPresent(Double.self, forKey: .durationSeconds)
+        let rawDurationAsDouble = try? c.decodeIfPresent(Double.self, forKey: .duration)
+        let rawDurationAsString = try? c.decodeIfPresent(String.self, forKey: .duration)
+        if let d = rawDurationSeconds.flatMap({ $0 }) {
             durationSeconds = d
             durationLabel = nil
-        } else if let s = try? c.decodeIfPresent(String.self, forKey: .duration) {
-            durationLabel = s
+        } else if let d = rawDurationAsDouble.flatMap({ $0 }) {
+            durationSeconds = d
+            durationLabel = nil
+        } else if let s = rawDurationAsString.flatMap({ $0 }) {
             durationSeconds = nil
+            durationLabel = s
         } else {
             durationSeconds = nil
             durationLabel = nil
@@ -516,34 +528,57 @@ actor TranscricaoClient {
         throw APIError.unknown
     }
 
-    /// Shared SSE consumer — reads `event:` / `data:` pairs and emits parsed events.
+    /// Shared SSE consumer — reads `data:` frames. The backend emits
+    /// `data: {"type":"...", ...}\n\n` without an `event:` prefix, so the
+    /// discriminator lives inside the JSON payload.
     private func consumeSSE(
         bytes: URLSession.AsyncBytes,
         continuation: AsyncThrowingStream<TranscricaoSSEEvent, Error>.Continuation
     ) async throws {
-        var eventType = ""
         var dataLines: [String] = []
+        var accumulatedTranscript = ""
+        var accumulatedSummary = ""
+        var accumulatedCards: [TranscriptionFlashcard] = []
         for try await line in bytes.lines {
-            if line.hasPrefix("event:") {
-                eventType = String(line.dropFirst(6)).trimmingCharacters(in: .whitespaces)
-            } else if line.hasPrefix("data:") {
+            if line.hasPrefix("data:") {
                 let content = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
                 dataLines.append(content)
             } else if line.isEmpty, !dataLines.isEmpty {
                 let rawJSON = dataLines.joined(separator: "\n")
                 dataLines = []
-                if let event = Self.parse(type: eventType, data: rawJSON) {
+                let parsed = Self.parseFrame(
+                    rawJSON: rawJSON,
+                    transcript: &accumulatedTranscript,
+                    summary: &accumulatedSummary,
+                    cards: &accumulatedCards
+                )
+                switch parsed {
+                case .yield(let event):
                     continuation.yield(event)
-                    switch event {
-                    case .complete, .error:
-                        continuation.finish()
-                        return
-                    default:
-                        break
-                    }
+                case .finishOK:
+                    continuation.yield(.complete(
+                        transcript: accumulatedTranscript,
+                        summary: accumulatedSummary,
+                        flashcards: accumulatedCards
+                    ))
+                    continuation.finish()
+                    return
+                case .finishError(let msg):
+                    continuation.yield(.error(message: msg))
+                    continuation.finish()
+                    return
+                case .ignore:
+                    break
                 }
-                eventType = ""
             }
+        }
+        // Stream closed without message_stop → treat as best-effort complete.
+        if !accumulatedTranscript.isEmpty {
+            continuation.yield(.complete(
+                transcript: accumulatedTranscript,
+                summary: accumulatedSummary,
+                flashcards: accumulatedCards
+            ))
         }
         continuation.finish()
     }
@@ -572,33 +607,61 @@ actor TranscricaoClient {
 
     // MARK: - SSE Parser
 
-    private static func parse(type: String, data: String) -> TranscricaoSSEEvent? {
-        guard let jsonData = data.data(using: .utf8),
+    /// Internal parse result. Backend streams individual frames
+    /// (progress/transcript/summary/flashcards/source_created/message_stop/error)
+    /// and finishes with `message_stop`; we accumulate partials here and emit
+    /// `.complete` once we see `message_stop`.
+    private enum ParsedFrame {
+        case yield(TranscricaoSSEEvent)
+        case finishOK
+        case finishError(String)
+        case ignore
+    }
+
+    private static func parseFrame(
+        rawJSON: String,
+        transcript: inout String,
+        summary: inout String,
+        cards: inout [TranscriptionFlashcard]
+    ) -> ParsedFrame {
+        guard let jsonData = rawJSON.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
-        else { return nil }
+        else { return .ignore }
+        let type = (json["type"] as? String) ?? ""
 
         switch type {
         case "progress":
-            return .progress(
+            return .yield(.progress(
                 stage: json["stage"] as? String ?? "",
                 percent: json["percent"] as? Int ?? 0
-            )
-        case "complete":
-            let transcript = json["transcript"] as? String ?? ""
-            let summary = json["summary"] as? String ?? ""
+            ))
+        case "transcript":
+            transcript = (json["content"] as? String) ?? transcript
+            return .ignore
+        case "summary":
+            summary = (json["content"] as? String) ?? summary
+            return .ignore
+        case "flashcards":
             let rawCards = json["flashcards"] as? [[String: String]] ?? []
-            let cards = rawCards.enumerated().map { idx, card in
+            cards = rawCards.enumerated().map { idx, card in
                 TranscriptionFlashcard(
                     id: card["id"] ?? "\(idx)",
                     front: card["front"] ?? "",
                     back: card["back"] ?? ""
                 )
             }
-            return .complete(transcript: transcript, summary: summary, flashcards: cards)
+            return .ignore
+        case "source_created":
+            return .ignore
+        case "message_stop":
+            return .finishOK
         case "error":
-            return .error(message: json["message"] as? String ?? "Erro desconhecido")
+            let msg = (json["content"] as? String)
+                ?? (json["message"] as? String)
+                ?? "Erro desconhecido"
+            return .finishError(msg)
         default:
-            return nil
+            return .ignore
         }
     }
 }

--- a/VitaAI/Core/Network/VitaAPI.swift
+++ b/VitaAI/Core/Network/VitaAPI.swift
@@ -188,6 +188,16 @@ actor VitaAPI {
         try await client.get("studio/sources/\(id)")
     }
 
+    private struct RenameStudioSourceBody: Encodable { let title: String }
+
+    func renameStudioSource(id: String, title: String) async throws {
+        try await client.patch("studio/sources/\(id)", body: RenameStudioSourceBody(title: title))
+    }
+
+    func deleteStudioSource(id: String) async throws {
+        try await client.delete("studio/sources/\(id)")
+    }
+
     func getStudioOutputs(sourceId: String) async throws -> StudioOutputsResponse {
         try await client.get("studio/outputs", queryItems: [
             URLQueryItem(name: "sourceId", value: sourceId),

--- a/VitaAI/Features/Transcricao/TranscricaoAudioPlayer.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoAudioPlayer.swift
@@ -31,6 +31,23 @@ final class TranscricaoAudioPlayer: ObservableObject {
 
     // MARK: - Public
 
+    /// Prepare audio from a presigned R2 GET URL (gold standard — no backend
+    /// roundtrip needed, backend attaches the URL to the source metadata).
+    func prepareFromUrl(_ signedUrl: String, words: [WhisperWord] = []) {
+        cleanup()
+        self.words = words
+        isLoading = true
+        error = nil
+
+        guard let url = URL(string: signedUrl) else {
+            error = "URL inválida"
+            isLoading = false
+            return
+        }
+        let asset = AVURLAsset(url: url)
+        setupPlayer(with: asset)
+    }
+
     /// Prepare audio from R2 via /api/files/:id/download (gold standard)
     func prepareFromFileId(fileId: String, tokenStore: TokenStore, words: [WhisperWord] = []) {
         cleanup()

--- a/VitaAI/Features/Transcricao/TranscricaoDetailSheet.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoDetailSheet.swift
@@ -4,6 +4,12 @@ import SwiftUI
 
 struct TranscricaoDetailSheet: View {
     let recording: TranscricaoEntry
+    /// Called after a successful rename so the parent list can refresh without
+    /// a full reload.
+    var onRenamed: ((String) -> Void)? = nil
+    /// Called after a successful delete so the parent list can drop the row.
+    var onDeleted: (() -> Void)? = nil
+
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appContainer) private var container
 
@@ -17,6 +23,24 @@ struct TranscricaoDetailSheet: View {
     @State private var professorSignals: [ProfessorSignals.Signal] = []
     @State private var showKaraoke = false
     @State private var hasAudioFile = false
+
+    // Actions menu state.
+    @State private var liveTitle: String
+    @State private var showRenameDialog = false
+    @State private var renameValue: String = ""
+    @State private var showDeleteConfirm = false
+    @State private var showShareSheet = false
+    @State private var actionBusy = false
+    @State private var actionError: String?
+
+    init(recording: TranscricaoEntry,
+         onRenamed: ((String) -> Void)? = nil,
+         onDeleted: (() -> Void)? = nil) {
+        self.recording = recording
+        self.onRenamed = onRenamed
+        self.onDeleted = onDeleted
+        self._liveTitle = State(initialValue: recording.title)
+    }
 
     private var displayStatus: RecordingStatus {
         recording.isTranscribed ? .transcribed : .pending
@@ -133,7 +157,7 @@ struct TranscricaoDetailSheet: View {
             .buttonStyle(.plain)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(recording.title.isEmpty ? "Gravação" : recording.title)
+                Text(liveTitle.isEmpty ? "Gravação" : liveTitle)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(Color.white.opacity(0.90))
                     .lineLimit(1)
@@ -153,6 +177,8 @@ struct TranscricaoDetailSheet: View {
 
             Spacer()
             TranscricaoStatusBadge(status: displayStatus)
+
+            actionsMenu
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
@@ -160,6 +186,127 @@ struct TranscricaoDetailSheet: View {
         .overlay(alignment: .bottom) {
             Rectangle().fill(VitaColors.accent.opacity(0.10)).frame(height: 1)
         }
+    }
+
+    // MARK: - Actions menu
+
+    private var actionsMenu: some View {
+        Menu {
+            Button {
+                renameValue = liveTitle
+                showRenameDialog = true
+            } label: {
+                Label("Renomear", systemImage: "pencil")
+            }
+            Button {
+                UIPasteboard.general.string = fullTranscript
+            } label: {
+                Label("Copiar transcrição", systemImage: "doc.on.doc")
+            }
+            .disabled(fullTranscript.isEmpty)
+            Button {
+                showShareSheet = true
+            } label: {
+                Label("Compartilhar", systemImage: "square.and.arrow.up")
+            }
+            .disabled(fullTranscript.isEmpty)
+            Divider()
+            Button(role: .destructive) {
+                showDeleteConfirm = true
+            } label: {
+                Label("Excluir", systemImage: "trash")
+            }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(VitaColors.accent.opacity(0.08))
+                    .frame(width: 32, height: 32)
+                    .overlay(Circle().stroke(VitaColors.accent.opacity(0.18), lineWidth: 1))
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(VitaColors.accentLight.opacity(0.70))
+            }
+            .frame(minWidth: 44, minHeight: 44)
+        }
+        .disabled(actionBusy)
+        .alert("Renomear gravação", isPresented: $showRenameDialog) {
+            TextField("Título", text: $renameValue)
+            Button("Cancelar", role: .cancel) { }
+            Button("Salvar") { Task { await performRename() } }
+                .disabled(renameValue.trimmingCharacters(in: .whitespaces).isEmpty)
+        } message: {
+            Text("Defina um nome mais fácil de encontrar depois.")
+        }
+        .confirmationDialog(
+            "Excluir esta gravação?",
+            isPresented: $showDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Excluir", role: .destructive) { Task { await performDelete() } }
+            Button("Cancelar", role: .cancel) { }
+        } message: {
+            Text("O áudio, a transcrição e os resumos gerados serão removidos. Não dá pra desfazer.")
+        }
+        .sheet(isPresented: $showShareSheet) {
+            TranscricaoShareSheet(items: shareItems)
+        }
+        .overlay(alignment: .bottom) {
+            if let err = actionError {
+                Text(err)
+                    .font(.system(size: 11))
+                    .foregroundStyle(VitaColors.dataRed.opacity(0.9))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.thinMaterial)
+                    .clipShape(Capsule())
+                    .padding(.bottom, 12)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private var shareItems: [Any] {
+        var items: [Any] = []
+        let title = liveTitle.isEmpty ? "Gravação" : liveTitle
+        let body = fullTranscript.isEmpty ? title : "\(title)\n\n\(fullTranscript)"
+        items.append(body)
+        return items
+    }
+
+    private func performRename() async {
+        let newTitle = renameValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !newTitle.isEmpty else { return }
+        actionBusy = true
+        actionError = nil
+        do {
+            try await container.api.renameStudioSource(id: recording.id, title: newTitle)
+            liveTitle = newTitle
+            onRenamed?(newTitle)
+        } catch {
+            actionError = "Falha ao renomear"
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                await MainActor.run { actionError = nil }
+            }
+        }
+        actionBusy = false
+    }
+
+    private func performDelete() async {
+        actionBusy = true
+        actionError = nil
+        do {
+            try await container.api.deleteStudioSource(id: recording.id)
+            onDeleted?()
+            dismiss()
+        } catch {
+            actionError = "Falha ao excluir"
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                await MainActor.run { actionError = nil }
+            }
+        }
+        actionBusy = false
     }
 
     // MARK: - Loading
@@ -261,10 +408,14 @@ struct TranscricaoDetailSheet: View {
                 professorSignals = ProfessorSignals.detect(in: transcript)
             }
 
-            // Prepare audio player if we have a file
+            // Prepare audio player if we have a file. Preferred path is the
+            // presigned R2 URL the backend bakes into metadata — no extra
+            // /files roundtrip needed.
             if detail.type == "audio" {
-                if let audioFileId = detail.metadata?.audioFileId {
-                    // Gold standard: stream from R2 via files API
+                if let audioUrl = detail.metadata?.audioUrl, !audioUrl.isEmpty {
+                    hasAudioFile = true
+                    audioPlayer.prepareFromUrl(audioUrl, words: allWords)
+                } else if let audioFileId = detail.metadata?.audioFileId {
                     hasAudioFile = true
                     audioPlayer.prepareFromFileId(
                         fileId: audioFileId,
@@ -272,7 +423,6 @@ struct TranscricaoDetailSheet: View {
                         words: allWords
                     )
                 } else if let fileName = detail.metadata?.fileName {
-                    // Legacy: stream from studio upload
                     hasAudioFile = true
                     audioPlayer.prepare(
                         fileName: fileName,
@@ -287,6 +437,18 @@ struct TranscricaoDetailSheet: View {
         }
         isLoading = false
     }
+}
+
+// MARK: - Share Sheet (UIActivityViewController bridge)
+
+private struct TranscricaoShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
 }
 
 // MARK: - Real Transcript Section

--- a/VitaAI/Features/Transcricao/TranscricaoScreen.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoScreen.swift
@@ -26,14 +26,25 @@ struct TranscricaoScreen: View {
         .onAppear {
             if viewModel == nil {
                 viewModel = TranscricaoViewModel(client: container.transcricaoClient, api: container.api, gamificationEvents: container.gamificationEvents)
-                Task {
-                    await viewModel?.loadRecordings()
-                    SentrySDK.reportFullyDisplayed()
-                }
+            }
+            // Always refresh the list on re-enter so transcriptions that
+            // finished while the user was on another tab show up immediately.
+            // Before this the list was only seeded on first mount and a user
+            // that navigated away mid-processing returned to a blank state.
+            Task {
+                await viewModel?.loadRecordings()
+                SentrySDK.reportFullyDisplayed()
             }
         }
         .onDisappear {
-            viewModel?.reset()
+            // If the user is still recording, stop capture so the mic is
+            // released; but NEVER reset the processing pipeline — upload /
+            // transcribe / summary runs server-side and the list refresh on
+            // re-enter will show the result. Calling reset() here was the
+            // root cause of "ficou transcrevendo pra sempre".
+            if viewModel?.phase == .recording {
+                viewModel?.stopRecording()
+            }
         }
         .trackScreen("Transcricao")
     }
@@ -182,7 +193,16 @@ private struct TranscricaoContent: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         // Detail sheet when tapping a recording
         .sheet(item: $selectedRecording) { rec in
-            TranscricaoDetailSheet(recording: rec)
+            TranscricaoDetailSheet(
+                recording: rec,
+                onRenamed: { newTitle in
+                    Task { await viewModel.loadRecordings() }
+                    _ = newTitle
+                },
+                onDeleted: {
+                    withAnimation { viewModel.removeRecordingLocally(id: rec.id) }
+                }
+            )
         }
         // Disciplines loaded from appData.gradesResponse (no separate API call needed)
     }


### PR DESCRIPTION
## Summary
- Fixes the iOS side of the \"transcrevendo pra sempre 5%\" bug. Pair with by-mav/vitaai-web#PR from the same session (backend SSE was fine; client parser was wrong and lifecycle was killing the task).
- Adds real detail actions: Renomear, Compartilhar, Copiar, Excluir.
- Unifies audio playback on the new signed \`audioUrl\` attached to GET /studio/sources/:id.

## Root causes
1. **SSE parser mismatch** — client expected \`event: progress\\ndata: ...\`; backend only emits \`data: {\"type\":...}\`. Switch statement fell through on every frame so nothing ever advanced past the locally-yielded 5%.
2. **TranscricaoScreen.onDisappear called reset()** which cancelled the upload task; navigating to another tab literally killed the in-flight transcription on the client side.
3. **Detail sheet had no audio / no text / no actions** because backend wasn't exposing \`chunks\` + \`audioUrl\` and iOS had no rename/delete/share UI.

## Test plan
- [x] Build: \`./scripts/dev-sim.sh\` → ** BUILD SUCCEEDED **.
- [x] E2E backend (curl via Tailscale): upload-url → PUT R2 → POST /ai/transcribe → **intentionally disconnect at 30s** → wait 90s → GET /studio/sources/:id returns \`status=ready, chunks=1, segments=1, audioUrl present, audioR2Key set, title=\"Gravação DD/MM HH:MM\"\`.
- [x] PATCH /studio/sources/:id → title updated.
- [x] DELETE /studio/sources/:id → subsequent GET 404.
- [ ] iOS sim manual verification tomorrow by @mav: record → navigate away → return → detail shows text + audio + menu actions.