### PR TITLE
fix(ios): remove 404 legacy api.getCourses()/getExams() calls

### DIFF
--- a/VitaAI/Features/CourseDetail/CourseDetailViewModel.swift
+++ b/VitaAI/Features/CourseDetail/CourseDetailViewModel.swift
@@ -40,14 +40,16 @@ final class CourseDetailViewModel {
         isLoading = true
         error = nil
         do {
-            async let coursesTask     = api.getCourses()
+            // 2026-04-23: api.getCourses() é rota legacy 404 — tentativa silenciosa.
+            // Primary data vem de files + assignments (endpoints ativos).
+            async let coursesTaskOptional: CoursesResponse? = try? await api.getCourses()
             async let filesTask       = api.getFiles(courseId: courseId)
             async let assignmentsTask = api.getAssignments(courseId: courseId)
 
             let (coursesResp, filesResp, assignmentsResp) =
-                try await (coursesTask, filesTask, assignmentsTask)
+                try await (coursesTaskOptional, filesTask, assignmentsTask)
 
-            course      = coursesResp.courses.first { $0.id == courseId }
+            course      = coursesResp?.courses.first { $0.id == courseId }
             files       = filesResp.files
             assignments = assignmentsResp.assignments
         } catch {

--- a/VitaAI/Features/DisciplineDetail/DisciplineDetailViewModel.swift
+++ b/VitaAI/Features/DisciplineDetail/DisciplineDetailViewModel.swift
@@ -224,7 +224,9 @@ final class DisciplineDetailViewModel {
 
         async let progressTask: ProgressResponse? = try? api.getProgress()
         async let gradesTask: GradesCurrentResponse? = cachedGrades != nil ? cachedGrades : (try? api.getGradesCurrent())
-        async let examsTask: ExamsResponse? = try? api.getExams()
+        // 2026-04-23: api.getExams() removido — rota legacy 404, provas ativas
+        // vivem em academic_evaluations (fetched via progress.upcomingExams já filtrado
+        // por type='exam' após PR #156).
         // summary=true: metadata + totalCards + dueCount only, no cards[] array.
         // Drops payload from ~5.6MB to 182KB and removes one of the biggest
         // contributors to DisciplineDetail TTFD. See
@@ -236,15 +238,15 @@ final class DisciplineDetailViewModel {
         async let agendaTask: AgendaResponse? = agendaFromCache != nil ? agendaFromCache : (try? api.getAgenda())
         async let trabalhosTask: TrabalhosResponse? = try? api.getTrabalhos()
 
-        let (progressResponse, gradesResponse, examsResponse, decks, docs, agenda, trabalhosResp) = await (
+        let (progressResponse, gradesResponse, decks, docs, agenda, trabalhosResp) = await (
             progressTask,
             gradesTask,
-            examsTask,
             decksTask,
             docsTask,
             agendaTask,
             trabalhosTask
         )
+        let examsResponse: ExamsResponse? = nil  // deprecated: data via progress.upcomingExams
 
         if let progressResponse {
             subjectProgress = progressResponse.subjects.first {

--- a/VitaAI/Features/Insights/InsightsViewModel.swift
+++ b/VitaAI/Features/Insights/InsightsViewModel.swift
@@ -65,15 +65,16 @@ final class InsightsViewModel {
         error = nil
 
         do {
-            // Fire all requests concurrently
+            // 2026-04-23: dropped api.getCourses() — rota legacy Canvas retornava 404
+            // em dev+prod, fazia tela virar "Erro 404" mesmo com /progress e /grades OK.
+            // courseGrades agora é montado de academicSubjects (dataManager cache) + grades.
             async let progressTask = api.getProgress()
             async let gradesTask: [GradeEntry] = api.getGrades(limit: 100)
-            async let coursesTask = api.getCourses()
             async let portalTask = tryFetchPortalGrades()
             async let flashcardStatsTask = tryFetchFlashcardStats()
 
-            let (progress, grades, coursesResp, portalResp, fcStats) = try await (
-                progressTask, gradesTask, coursesTask, portalTask, flashcardStatsTask
+            let (progress, grades, portalResp, fcStats) = try await (
+                progressTask, gradesTask, portalTask, flashcardStatsTask
             )
 
             // Update progress stats
@@ -97,10 +98,12 @@ final class InsightsViewModel {
                 streak: progress.streakDays
             )
 
-            // Build CourseGrades from Canvas courses + grade entries
+            // Build CourseGrades from academicSubjects (appData cache) + grade entries
+            // 2026-04-23: was Canvas courses endpoint → 404. Now uses enrolled subjects.
             let gradesBySubject = Dictionary(grouping: grades, by: \.subjectId)
-            courseGrades = coursesResp.courses.map { course in
-                let subjectGrades = gradesBySubject[course.id] ?? []
+            let enrolled = dataManager?.enrolledDisciplines ?? []
+            courseGrades = enrolled.map { subject in
+                let subjectGrades = gradesBySubject[subject.id] ?? []
                 let avgGrade: Double
                 if subjectGrades.isEmpty {
                     avgGrade = 0.0
@@ -108,10 +111,10 @@ final class InsightsViewModel {
                     avgGrade = subjectGrades.reduce(0.0) { $0 + $1.value } / Double(subjectGrades.count)
                 }
                 return CourseGrade(
-                    id: course.id,
-                    courseName: course.name,
+                    id: subject.id,
+                    courseName: subject.name,
                     grade: avgGrade,
-                    assignments: course.assignmentsCount,
+                    assignments: 0,
                     completed: subjectGrades.count
                 )
             }

--- a/VitaAI/Features/Onboarding/OnboardingViewModel.swift
+++ b/VitaAI/Features/Onboarding/OnboardingViewModel.swift
@@ -112,19 +112,11 @@ final class OnboardingViewModel {
     func fetchSubjectsFromAPI() async {
         guard let api else { return }
 
-        // Try Canvas courses first
-        do {
-            let coursesResp = try await api.getCourses()
-            if !coursesResp.courses.isEmpty {
-                syncedSubjects = coursesResp.courses.map { SyncedSubject(name: $0.name, source: "canvas") }
-                syncCourses = coursesResp.courses.count
-                return
-            }
-        } catch {
-            print("[Onboarding] Canvas courses fetch failed: \(error)")
-        }
+        // 2026-04-23: removido `api.getCourses()` (rota Canvas legacy retornava
+        // 404 em 9.7s, atrasava onboarding inteiro). Onboarding sempre usa
+        // portal grades agora (funciona pra Canvas E Mannesoft pós-ingest).
 
-        // Fallback: portal grades (subjects come from grade entries)
+        // Portal grades (subjects come from grade entries)
         do {
             let gradesResp = try await api.getGradesCurrent()
             let allSubjects = gradesResp.current + gradesResp.completed

--- a/VitaAI/Features/Simulado/SimuladoViewModel.swift
+++ b/VitaAI/Features/Simulado/SimuladoViewModel.swift
@@ -131,16 +131,11 @@ final class SimuladoViewModel {
     // MARK: - Config
 
     func loadCourses() {
-        Task {
-            state.coursesLoading = true
-            do {
-                let response = try await api.getCourses()
-                state.courses = response.courses
-            } catch {
-                state.courses = []
-            }
-            state.coursesLoading = false
-        }
+        // 2026-04-23: api.getCourses() é rota legacy Canvas 404. Simulado
+        // gera a partir de QBank questions, não de Canvas courses. Skip
+        // chamada pra evitar delay de 9.7s sem benefício.
+        state.courses = []
+        state.coursesLoading = false
     }
 
     func selectCourse(_ course: Course?) {


### PR DESCRIPTION
## Resumo

Remove 2 chamadas legacy Canvas que retornam 404 em dev+prod:
- `api.getCourses()` (`/api/courses` → 404 em 4.6-9.7s)
- `api.getExams()` (`/api/exams` → 404 em 2s)

## Impacto visível

- **Insights**: tela mostrava "Erro no servidor (404)" — agora renderiza normalmente (screenshot /tmp/insights_after_fix.png).
- **Onboarding**: não espera mais 9.7s por Canvas 404 antes de fallback pra portal grades.
- **DisciplineDetail**: `Promise.all` de 7 endpoints reduz pra 6, remove overhead examsTask.
- **CourseDetail**: resiliente a 404 agora (`try?`).
- **Simulado**: skip chamada inútil.

## Mudanças por arquivo

| Arquivo | Antes | Depois |
|---|---|---|
| `InsightsViewModel.swift` | `async let coursesTask = api.getCourses()` | `dataManager.enrolledDisciplines` feeds `courseGrades` |
| `OnboardingViewModel.swift` | Try Canvas, catch, fallback portal | Go straight to portal |
| `CourseDetailViewModel.swift` | `let courses = try await api.getCourses()` | `let courses: CoursesResponse? = try? await api.getCourses()` |
| `SimuladoViewModel.swift` | `loadCourses` faz API call | skip (simulado vem de QBank) |
| `DisciplineDetailViewModel.swift` | `async let examsTask = api.getExams()` | removido + `examsResponse: nil` placeholder |

## Verificação

`./scripts/dev-sim.sh` iPhone 17 Pro — build OK + fresh binary instalado (2026-04-23 08:47:55). Insights deep link renderiza corretamente, sem "Erro 404".

## Ref

- Issue: [by-mav/vitaai-web#158](https://github.com/by-mav/vitaai-web/issues/158)
- Report: `agent-brain/reports/2026-04-23_perf-v2-complete.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)