### PR TITLE
fix(ios): onboarding speech bubble + transcribe language picker stacked + current-semester filter + debounce

### DIFF
--- a/VitaAI/Features/Onboarding/OnboardingWhatsAppLinkSheet.swift
+++ b/VitaAI/Features/Onboarding/OnboardingWhatsAppLinkSheet.swift
@@ -95,7 +95,7 @@ struct OnboardingWhatsAppLinkSheet: View {
 
     @ViewBuilder private var connectedState: some View {
         Text("WhatsApp conectado!").font(.title2.bold()).foregroundStyle(.white)
-        Text("A VITA vai te mandar uma mensagem de boas-vindas")
+        Text("Vita vai te mandar uma mensagem de boas-vindas")
             .font(.subheadline).foregroundStyle(.gray)
     }
 }

--- a/VitaAI/Features/Onboarding/Steps/ExtrasStep.swift
+++ b/VitaAI/Features/Onboarding/Steps/ExtrasStep.swift
@@ -12,11 +12,10 @@ struct ExtrasStep: View {
     let onConnectIntegration: (String) -> Void
 
     var body: some View {
+        // Speech bubble is rendered by the parent VitaOnboarding shell
+        // (via typeText on step transition). Duplicating it here was the
+        // root cause of "two bubbles stacked" (incident 2026-04-23).
         VStack(alignment: .leading, spacing: 18) {
-            OnboardingSpeechBubble(
-                text: "A VITA também vive fora da faculdade. Conecta o que fizer sentido — tudo opcional."
-            )
-
             VStack(spacing: 10) {
                 extraCard(
                     letter: "W",

--- a/VitaAI/Features/Onboarding/VitaOnboarding.swift
+++ b/VitaAI/Features/Onboarding/VitaOnboarding.swift
@@ -508,8 +508,20 @@ struct VitaOnboarding: View {
                 typeText(first.isEmpty ? String(localized: "onboarding_done_speech") : String(localized: "onboarding_done_speech_name").replacingOccurrences(of: "%@", with: first))
                 Task { await saveOnboarding() }
 
+            case .extras:
+                // Without this the previous step's speech (e.g. "Detectei 2
+                // sistemas" from .connect) stayed on screen because the
+                // default branch below never cleared speechText. The
+                // ExtrasStep used to render its own speech bubble on top,
+                // which produced two bubbles overlapping.
+                mascotState = .happy
+                typeText(String(localized: "onboarding_extras_speech"))
+
             default:
-                break
+                // Defensive: always clear the previous speech when the step
+                // transitions into something that doesn't type its own text,
+                // so stale captions never carry over.
+                speechText = ""
             }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {

--- a/VitaAI/Features/Transcricao/TranscricaoRecorderContent.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoRecorderContent.swift
@@ -54,17 +54,21 @@ struct TranscricaoRecorderArea: View {
                     .frame(height: 36)
                     .padding(.top, 8)
 
-                // Discipline + language pickers (always enabled, never during record)
-                HStack(spacing: 8) {
+                // Discipline + language pickers stacked vertically so each
+                // one has the full row width — avoids "Auto..." truncation
+                // when the discipline name is long.
+                VStack(alignment: .leading, spacing: 6) {
                     TranscricaoDisciplinePicker(
                         selected: $selectedDiscipline,
                         disciplines: disciplines,
                         disabled: isRecording
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     TranscricaoLanguagePicker(
                         selected: $selectedLanguage,
                         disabled: isRecording
                     )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .padding(.top, 6)
 

--- a/VitaAI/Features/Transcricao/TranscricaoScreen.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoScreen.swift
@@ -65,12 +65,14 @@ private struct TranscricaoContent: View {
     @State private var selectedFilter: String? = nil
     @State private var selectedRecording: TranscricaoEntry? = nil
 
-    /// Disciplines from academic_subjects via gradesResponse (already loaded by AppDataManager)
+    /// Disciplines currently enrolled — filter chips and the recorder
+    /// picker only show what the user is studying THIS semester. Before
+    /// this we merged `current + completed` which ballooned to hundreds
+    /// of subjects from the student's whole history; Rafael: "ta
+    /// mostrando 342394832984 disciplinas".
     private var disciplines: [String] {
         let current = appData.gradesResponse?.current ?? []
-        let completed = appData.gradesResponse?.completed ?? []
-        let all = current + completed
-        return all.map(\.subjectName).filter { !$0.isEmpty }
+        return current.map(\.subjectName).filter { !$0.isEmpty }
     }
 
     /// Whether the pipeline is actively processing (upload/transcribe/summarize/flashcards)

--- a/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
+++ b/VitaAI/Features/Transcricao/TranscricaoViewModel.swift
@@ -102,12 +102,25 @@ final class TranscricaoViewModel {
 
     // MARK: - Public API
 
-    /// Load saved recordings from the API
-    func loadRecordings() async {
+    /// Timestamp of last successful load — used to debounce repeated calls.
+    /// SwiftUI may fire `.task` / `.onAppear` multiple times on sheet dismiss,
+    /// layout changes, or tab switches; this keeps us from re-fetching the
+    /// same list 6× in a row (incident 2026-04-23 — Rafael viu "30s pra
+    /// carregar 18 gravações" porque iOS disparava 6 requests em sequência).
+    private var lastLoadAt: Date = .distantPast
+
+    /// Load saved recordings from the API. Debounced — skips if called
+    /// again within 2s. Pull-to-refresh / post-completion passam `force: true`.
+    func loadRecordings(force: Bool = false) async {
         guard let api else { return }
+        if !force && Date().timeIntervalSince(lastLoadAt) < 2 {
+            NSLog("[TranscricaoVM] loadRecordings debounced (last=%.1fs ago)", Date().timeIntervalSince(lastLoadAt))
+            return
+        }
         recordingsLoading = true
         do {
             recordings = try await api.getTranscricoes()
+            lastLoadAt = Date()
             for r in recordings {
                 NSLog("[TranscricaoVM] Recording: id=%@ title=%@ status=%@ isTranscribed=%d", r.id, r.title, r.status ?? "nil", r.isTranscribed ? 1 : 0)
             }
@@ -196,7 +209,7 @@ final class TranscricaoViewModel {
                 self.pollingTask?.cancel()
                 self.phase = .done
                 self.stopProcessingTimer()
-                await self.loadRecordings()
+                await self.loadRecordings(force: true)
             }
         }
     }
@@ -225,7 +238,7 @@ final class TranscricaoViewModel {
                                 .joined(separator: "\n\n") ?? self.transcript
                             self.stopProcessingTimer()
                             self.watchdogTask?.cancel()
-                            Task { await self.loadRecordings() }
+                            Task { await self.loadRecordings(force: true) }
                         }
                     }
                     return
@@ -469,8 +482,8 @@ final class TranscricaoViewModel {
                     // Kick a list refresh so the new recording shows up under
                     // "Transcrições de hoje" without the user needing to
                     // navigate away and back. Runs concurrently with the
-                    // gamification ping below.
-                    Task { await self.loadRecordings() }
+                    // gamification ping below. `force: true` bypassa debounce.
+                    Task { await self.loadRecordings(force: true) }
                     VitaPostHogConfig.capture(event: "transcription_completed", properties: [
                         "word_count": t.split(separator: " ").count,
                         "flashcards_generated": cards.count,
@@ -499,8 +512,8 @@ final class TranscricaoViewModel {
                         stopProcessingTimer()
                     }
                     // Either way, refresh the list so the user sees whatever
-                    // did land server-side.
-                    Task { await self.loadRecordings() }
+                    // did land server-side. `force: true` bypassa debounce.
+                    Task { await self.loadRecordings(force: true) }
                     VitaPostHogConfig.capture(event: "transcription_upload_failed", properties: [
                         "reason": msg,
                     ])

--- a/VitaAI/Resources/en.lproj/Localizable.strings
+++ b/VitaAI/Resources/en.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 "onboarding_done_speech_name" = "All set, %@! Everything configured. Let's study!";
 "onboarding_subjects_speech" = "Tell me how hard each subject is and I'll build your personalized study plan.";
 "onboarding_notifications_speech" = "Can I notify you when exams are coming and flashcards are due?";
+"onboarding_extras_speech" = "Vita also lives outside your campus. Connect what makes sense — all optional.";
 "onboarding_trial_speech" = "All set! Try Vita Pro free for 7 days, no commitment.";
 
 /* Onboarding buttons */

--- a/VitaAI/Resources/es.lproj/Localizable.strings
+++ b/VitaAI/Resources/es.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 "onboarding_done_speech_name" = "¡Listo, %@! Todo configurado. ¡A estudiar!";
 "onboarding_subjects_speech" = "Dime la dificultad de cada materia y armo tu plan de estudio personalizado.";
 "onboarding_notifications_speech" = "Puedo avisarte cuando se acerquen examenes y flashcards pendientes?";
+"onboarding_extras_speech" = "Vita tambien vive fuera del campus. Conecta lo que tenga sentido — todo opcional.";
 "onboarding_trial_speech" = "Todo listo! Prueba Vita Pro gratis por 7 dias, sin compromiso.";
 
 /* Onboarding buttons */

--- a/VitaAI/Resources/pt-BR.lproj/Localizable.strings
+++ b/VitaAI/Resources/pt-BR.lproj/Localizable.strings
@@ -350,6 +350,7 @@
 "onboarding_done_speech_name" = "Pronto, %@! Tudo configurado. Bora estudar!";
 "onboarding_subjects_speech" = "Me diz a dificuldade de cada materia que eu monto teu plano de estudo personalizado.";
 "onboarding_notifications_speech" = "Posso te avisar quando tem prova chegando e flashcards pendentes?";
+"onboarding_extras_speech" = "Vita também vive fora da faculdade. Conecta o que fizer sentido — tudo opcional.";
 "onboarding_trial_speech" = "Tudo pronto! Experimenta Vita completo por 7 dias, sem compromisso.";
 
 /* Onboarding buttons */


### PR DESCRIPTION
## Summary

Small UX polishes on iOS pulled from orphan branches that never got mergeado (part of the 2026-04-23 branch cleanup). 4 commits, all isolated, zero cross-dependencies.

## Commits

- **onboarding** (`6ae0df7`): fix duplicate speech bubble on ExtrasStep + "A VITA" typo → "Vita". Parent `VitaOnboarding` already renders the bubble; child `ExtrasStep` had a second copy stacked.
- **transcribe layout** (`9419c80`): stack language picker under discipline picker (was side-by-side, discipline chip truncated to "Auto..." on narrow widths).
- **transcribe data** (`d2f0935`): discipline filter shows only current-semester enrollments (before it merged `current + completed`, flooding UI with every past subject).
- **transcribe perf** (`d30d574`): debounce `loadRecordings()` to 2s window — SwiftUI fires `.task`/`.onAppear` 6× per sheet dismiss / tab switch; Rafael saw 30s to render 18 recordings.

## Test plan

- [x] Pre-commit build green (iphonesimulator)
- [x] Onboarding ExtrasStep renders single speech bubble saying "Vita também…"
- [x] Transcribe picker row has discipline chip full-width, language chip full-width below it
- [x] Disciplines dropdown only shows current semester
- [x] `loadRecordings` logs show debounced second call when sheet dismisses

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>